### PR TITLE
Switch to GHC 9.6 to use `ConstPtr`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
             patches = []; # Commit fe53ec693789afb44c899cad8c2df70c8f9f9023 is in 0.17.1.
           });
         });
-        haskellPackages = pkgs.haskellPackages.extend (final: prev: {
+        haskellPackages = pkgs.haskell.packages.ghc96.extend (final: prev: {
           wlhs-bindings = prev.callCabal2nix "wlhs-bindings" ./. { };
         });
       in {

--- a/src/WL/ServerCore.hsc
+++ b/src/WL/ServerCore.hsc
@@ -3,7 +3,8 @@ module WL.ServerCore where
 #include <wayland-server-core.h>
 
 import Foreign
-import Foreign.C.String
+import Foreign.C.ConstPtr
+import Foreign.C.Types
 
 import WL.Utils
 import WL.ServerProtocol
@@ -59,7 +60,7 @@ foreign import capi "wayland-server-core.h wl_display_destroy"
     wl_display_destroy :: Ptr WL_display -> IO ()
 
 foreign import capi "wayland-server-core.h wl_display_add_socket_auto"
-    wl_display_add_socket_auto :: Ptr WL_display -> IO CString
+    wl_display_add_socket_auto :: Ptr WL_display -> IO (ConstPtr CChar)
 
 foreign import capi "wayland-server-core.h wl_display_run"
     wl_display_run :: Ptr WL_display -> IO ()

--- a/wlhs-bindings.cabal
+++ b/wlhs-bindings.cabal
@@ -26,4 +26,4 @@ library
     default-language:   Haskell2010
     default-extensions: CApiFFI
     ghc-options:        -Wall -fno-show-valid-hole-fits
-    build-depends:      base >=4.16.4.0 && <5
+    build-depends:      base >=4.18 && <5


### PR DESCRIPTION
`base == 4.18.0.0` (GHC 9.6) introduced `ConstPtr` that allows FFI modules making use of `CApiFFI` to preserve `const`-ness of the types in the imported C functions. Making use of this fixes the compilation error in the generated C file.