### PR TITLE
Add wlr_input_device

### DIFF
--- a/src/WLR/Types/InputDevice.hsc
+++ b/src/WLR/Types/InputDevice.hsc
@@ -1,4 +1,5 @@
 {-# LANGUAGE EmptyDataDeriving #-}
+{-# LANGUAGE PatternSynonyms #-}
 
 module WLR.Types.InputDevice where
 
@@ -11,13 +12,24 @@ import Foreign.C.Types
 import WL.ServerCore
 
 type WLR_input_device_type = CInt
-#enum WLR_input_device_type, , \
-    WLR_INPUT_DEVICE_KEYBOARD, \
-    WLR_INPUT_DEVICE_POINTER, \
-    WLR_INPUT_DEVICE_TOUCH, \
-    WLR_INPUT_DEVICE_TABLET_TOOL, \
-    WLR_INPUT_DEVICE_TABLET_PAD, \
-    WLR_INPUT_DEVICE_SWITCH
+
+pattern WLR_INPUT_DEVICE_KEYBOARD :: (Eq a, Num a) => a
+pattern WLR_INPUT_DEVICE_KEYBOARD = #const WLR_INPUT_DEVICE_KEYBOARD
+
+pattern WLR_INPUT_DEVICE_POINTER :: (Eq a, Num a) => a
+pattern WLR_INPUT_DEVICE_POINTER = #const WLR_INPUT_DEVICE_POINTER
+
+pattern WLR_INPUT_DEVICE_TOUCH :: (Eq a, Num a) => a
+pattern WLR_INPUT_DEVICE_TOUCH = #const WLR_INPUT_DEVICE_TOUCH
+
+pattern WLR_INPUT_DEVICE_TABLET_TOOL :: (Eq a, Num a) => a
+pattern WLR_INPUT_DEVICE_TABLET_TOOL = #const WLR_INPUT_DEVICE_TABLET_TOOL
+
+pattern WLR_INPUT_DEVICE_TABLET_PAD :: (Eq a, Num a) => a
+pattern WLR_INPUT_DEVICE_TABLET_PAD = #const WLR_INPUT_DEVICE_TABLET_PAD
+
+pattern WLR_INPUT_DEVICE_SWITCH :: (Eq a, Num a) => a
+pattern WLR_INPUT_DEVICE_SWITCH = #const WLR_INPUT_DEVICE_SWITCH
 
 data {-# CTYPE "wlr/types/wlr_input_device.h" "struct wlr_input_device" #-} WLR_input_device
     = WLR_input_device

--- a/src/WLR/Types/InputDevice.hsc
+++ b/src/WLR/Types/InputDevice.hsc
@@ -1,0 +1,48 @@
+{-# LANGUAGE EmptyDataDeriving #-}
+
+module WLR.Types.InputDevice where
+
+#define WLR_USE_UNSTABLE
+#include <wlr/types/wlr_input_device.h>
+
+import Foreign
+import Foreign.C.Types
+
+import WL.ServerCore
+
+type WLR_input_device_type = CInt
+#enum WLR_input_device_type, , \
+    WLR_INPUT_DEVICE_KEYBOARD, \
+    WLR_INPUT_DEVICE_POINTER, \
+    WLR_INPUT_DEVICE_TOUCH, \
+    WLR_INPUT_DEVICE_TABLET_TOOL, \
+    WLR_INPUT_DEVICE_TABLET_PAD, \
+    WLR_INPUT_DEVICE_SWITCH
+
+data {-# CTYPE "wlr/types/wlr_input_device.h" "struct wlr_input_device" #-} WLR_input_device
+    = WLR_input_device
+    { wlr_input_device_type :: WLR_input_device_type
+    , wlr_input_device_vendor :: CUInt
+    , wlr_input_device_product :: CUInt
+    , wlr_input_device_name :: Ptr CChar
+    , wlr_input_device_events_destroy :: WL_signal
+    , wlr_input_device_data :: Ptr ()
+    } deriving (Show)
+
+instance Storable WLR_input_device where
+    alignment _ = #alignment struct wlr_input_device
+    sizeOf _ = #size struct wlr_input_device
+    peek ptr = WLR_input_device
+        <$> (#peek struct wlr_input_device, type) ptr
+        <*> (#peek struct wlr_input_device, vendor) ptr
+        <*> (#peek struct wlr_input_device, product) ptr
+        <*> (#peek struct wlr_input_device, name) ptr
+        <*> (#peek struct wlr_input_device, events.destroy) ptr
+        <*> (#peek struct wlr_input_device, data) ptr
+    poke ptr t = do
+        (#poke struct wlr_input_device, type) ptr $ wlr_input_device_type t
+        (#poke struct wlr_input_device, vendor) ptr $ wlr_input_device_vendor t
+        (#poke struct wlr_input_device, product) ptr $ wlr_input_device_product t
+        (#poke struct wlr_input_device, name) ptr $ wlr_input_device_name t
+        (#poke struct wlr_input_device, events.destroy) ptr $ wlr_input_device_events_destroy t
+        (#poke struct wlr_input_device, data) ptr $ wlr_input_device_data t

--- a/wlhs-bindings.cabal
+++ b/wlhs-bindings.cabal
@@ -22,6 +22,7 @@ library
         WLR.Render.DrmFormatSet
         WLR.Render.Renderer
         WLR.Types.Buffer
+        WLR.Types.InputDevice
         WLR.Util.Addon
         WLR.Version
 


### PR DESCRIPTION
First off: I'm a Haskell noob and this is my first time contributing, so I appreciate any feedback you are able to give.

For the most part, I just copied and modified existing code. What I was really uncertain about was how to handle enums (`wlr_input_device_type`). I figure that just returning a `CInt` isn't ideal, and I'm trying to heed [BurningWitness's advice](https://discourse.haskell.org/t/haskell-wlroots-bindings/8426/5?u=bullishonfunctional) and avoid cluttering things up with `newtype`s. Let me know if you have any better ideas than what I've currently got.

Lastly, I'm not too sure how to test these changes. I've just been making sure that I can load the module with ghci. Is there something I should do with cabal?