### PR TITLE
Wlr Pointer attempt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .stack-work/
 dist*/
 *~
+.direnv

--- a/src/WLR/Types/InputDevice.hsc
+++ b/src/WLR/Types/InputDevice.hsc
@@ -1,0 +1,48 @@
+{-# LANGUAGE EmptyDataDeriving #-}
+
+module WLR.Types.InputDevice where
+
+#define WLR_USE_UNSTABLE
+#include <wlr/types/wlr_input_device.h>
+
+import Foreign
+import Foreign.C.Types
+
+import WL.ServerCore
+
+type WLR_input_device_type = CInt
+#enum WLR_input_device_type, , \
+    WLR_INPUT_DEVICE_KEYBOARD, \
+    WLR_INPUT_DEVICE_POINTER, \
+    WLR_INPUT_DEVICE_TOUCH, \
+    WLR_INPUT_DEVICE_TABLET_TOOL, \
+    WLR_INPUT_DEVICE_TABLET_PAD, \
+    WLR_INPUT_DEVICE_SWITCH
+
+data {-# CTYPE "wlr/types/wlr_input_device.h" "struct wlr_input_device" #-} WLR_input_device
+    = WLR_input_device
+    { wlr_input_device_type :: WLR_input_device_type
+    , wlr_input_device_vendor :: CUInt
+    , wlr_input_device_product :: CUInt
+    , wlr_input_device_name :: Ptr CChar
+    , wlr_input_device_events_destroy :: WL_signal
+    , wlr_input_device_data :: Ptr ()
+    } deriving (Show)
+
+instance Storable WLR_input_device where
+    alignment _ = #alignment struct wlr_input_device
+    sizeOf _ = #size struct wlr_input_device
+    peek ptr = WLR_input_device
+        <$> (#peek struct wlr_input_device, type) ptr
+        <*> (#peek struct wlr_input_device, vendor) ptr
+        <*> (#peek struct wlr_input_device, product) ptr
+        <*> (#peek struct wlr_input_device, name) ptr
+        <*> (#peek struct wlr_input_device, events.destroy) ptr
+        <*> (#peek struct wlr_input_device, data) ptr
+    poke ptr t = do
+        (#poke struct wlr_input_device, type) ptr $ wlr_input_device_type t
+        (#poke struct wlr_input_device, vendor) ptr $ wlr_input_device_vendor t
+        (#poke struct wlr_input_device, product) ptr $ wlr_input_device_product t
+        (#poke struct wlr_input_device, name) ptr $ wlr_input_device_name t
+        (#poke struct wlr_input_device, events.destroy) ptr $ wlr_input_device_events_destroy t
+        (#poke struct wlr_input_device, data) ptr $ wlr_input_device_data t

--- a/src/WLR/Types/Pointer.hsc
+++ b/src/WLR/Types/Pointer.hsc
@@ -2,7 +2,6 @@
 module WLR.Types.Pointer (
     WLR_pointer(..)
     , WLR_pointer_events(..)
-    , WLR_pointer_data
     ) where
 
 #define WLR_USE_UNSTABLE
@@ -28,8 +27,6 @@ import WL.ServerCore (
 data {-# CTYPE "wlr/types/wlr_pointer.h" "struct wlr_pointer_impl" #-} WLR_pointer_impl
     deriving (Show)
 
-data WLR_pointer_data
-
 data {-# CTYPE "wlr/types/wlr_pointer.h" "struct wlr_pointer" #-} WLR_pointer
     = WLR_pointer
     { wlr_pointer_base :: Ptr WLR_input_device
@@ -39,7 +36,7 @@ data {-# CTYPE "wlr/types/wlr_pointer.h" "struct wlr_pointer" #-} WLR_pointer
 
     -- TODO what type is this? It's a void* in the C source
     -- void *data;
-    , wlr_pointer_data :: Ptr WLR_pointer_data
+    , wlr_pointer_data :: Ptr ()
     }
 
 instance Storable WLR_pointer where

--- a/src/WLR/Types/Pointer.hsc
+++ b/src/WLR/Types/Pointer.hsc
@@ -53,13 +53,19 @@ instance Storable WLR_pointer where
         -- what should I do?
         <*> (#peek struct wlr_pointer, events) ptr
         <*> (#peek struct wlr_pointer, data) ptr
+    poke ptr t = do
+        (#poke struct wlr_pointer, base) ptr $ wlr_pointer_base t
+        (#poke struct wlr_pointer, impl) ptr $ wlr_pointer_impl t
+        (#poke struct wlr_pointer, output_name) ptr $ wlr_pointer_output_name t
+        (#poke struct wlr_pointer, events) ptr $ wlr_pointer_events t
+        (#poke struct wlr_pointer, data) ptr $ wlr_pointer_data t
 
-{-# 
+{- 
  - TODO there were some source comments here that had some sort of struct
  - type specified, I guess it's a hint about the types???
  - I think I did the comment structure so that `struct wlr_pointer_motion_event` will show on hover
- - need to check that when I get my hls working ~ Matt
-#-}
+ - need to check that when I get my hls working ~ Matt t
+-}
 data WLR_pointer_events = WLR_pointer_events {
     -- |struct wlr_pointer_motion_event
     wlr_pointer_events_motion :: WL_signal

--- a/src/WLR/Types/Pointer.hsc
+++ b/src/WLR/Types/Pointer.hsc
@@ -1,3 +1,4 @@
+{-# LANGUAGE EmptyDataDeriving #-}
 module WLR.Types.Pointer (
     ) where
 
@@ -9,6 +10,10 @@ import Foreign.Ptr (
     )
 import Foreign.C.String (
     CString
+    )
+
+import WLR.Types.InputDevice (
+    WLR_input_device
     )
 
 data {-# CTYPE "wlr/types/wlr_pointer.h" "struct wlr_pointer_impl" #-} WLR_pointer_impl

--- a/src/WLR/Types/Pointer.hsc
+++ b/src/WLR/Types/Pointer.hsc
@@ -1,5 +1,8 @@
 {-# LANGUAGE EmptyDataDeriving #-}
 module WLR.Types.Pointer (
+    WLR_pointer(..)
+    , WLR_pointer_events(..)
+    , WLR_pointer_data
     ) where
 
 #define WLR_USE_UNSTABLE
@@ -25,7 +28,7 @@ import WL.ServerCore (
 data {-# CTYPE "wlr/types/wlr_pointer.h" "struct wlr_pointer_impl" #-} WLR_pointer_impl
     deriving (Show)
 
-data Wlr_pointer_data
+data WLR_pointer_data
 
 data {-# CTYPE "wlr/types/wlr_pointer.h" "struct wlr_pointer" #-} WLR_pointer
     = WLR_pointer
@@ -36,7 +39,7 @@ data {-# CTYPE "wlr/types/wlr_pointer.h" "struct wlr_pointer" #-} WLR_pointer
 
     -- TODO what type is this? It's a void* in the C source
     -- void *data;
-    , wlr_pointer_data :: Ptr Wlr_pointer_data
+    , wlr_pointer_data :: Ptr WLR_pointer_data
     }
 
 instance Storable WLR_pointer where

--- a/src/WLR/Types/Pointer.hsc
+++ b/src/WLR/Types/Pointer.hsc
@@ -91,20 +91,20 @@ data WLR_pointer_events = WLR_pointer_events {
 instance Storable WLR_pointer_events where
     -- Because this 'events' struct is defined within the pointer struct,
     -- does that mean that I can't use this #alignment???
-    alignment _ = #alignment struct wlr_pointer.events
-    sizeOf _ = #size struct wlr_pointer.events
-    peek ptr = WLR_pointer
-        <$> (#peek struct wlr_pointer.events, motion) ptr
-        <*> (#peek struct wlr_pointer.events, motion_absolute) ptr
-        <*> (#peek struct wlr_pointer.events, button) ptr
-        <*> (#peek struct wlr_pointer.events, axis) ptr
-        <*> (#peek struct wlr_pointer.events, frame) ptr
-        <*> (#peek struct wlr_pointer.events, swipe_begin) ptr
-        <*> (#peek struct wlr_pointer.events, swipe_update) ptr
-        <*> (#peek struct wlr_pointer.events, swipe_end) ptr
-        <*> (#peek struct wlr_pointer.events, pinch_begin) ptr
-        <*> (#peek struct wlr_pointer.events, pinch_update) ptr
-        <*> (#peek struct wlr_pointer.events, pinch_end) ptr
-        <*> (#peek struct wlr_pointer.events, hold_begin) ptr
-        <*> (#peek struct wlr_pointer.events, hold_end) ptr
+    -- alignment _ = #alignment struct wlr_pointer.events
+    -- sizeOf _ = #size struct wlr_pointer.events
+    peek ptr = WLR_pointer_events
+        <$> (#peek struct wlr_pointer, events.motion) ptr
+        <*> (#peek struct wlr_pointer, events.motion_absolute) ptr
+        <*> (#peek struct wlr_pointer, events.button) ptr
+        <*> (#peek struct wlr_pointer, events.axis) ptr
+        <*> (#peek struct wlr_pointer, events.frame) ptr
+        <*> (#peek struct wlr_pointer, events.swipe_begin) ptr
+        <*> (#peek struct wlr_pointer, events.swipe_update) ptr
+        <*> (#peek struct wlr_pointer, events.swipe_end) ptr
+        <*> (#peek struct wlr_pointer, events.pinch_begin) ptr
+        <*> (#peek struct wlr_pointer, events.pinch_update) ptr
+        <*> (#peek struct wlr_pointer, events.pinch_end) ptr
+        <*> (#peek struct wlr_pointer, events.hold_begin) ptr
+        <*> (#peek struct wlr_pointer, events.hold_end) ptr
 

--- a/src/WLR/Types/Pointer.hsc
+++ b/src/WLR/Types/Pointer.hsc
@@ -1,0 +1,40 @@
+module WLR.Types.Pointer (
+    ) where
+
+#define WLR_USE_UNSTABLE
+#include <wlr/types/wlr_pointer.h>
+
+data {-# CTYPE "wlr/types/wlr_pointer.h" "struct wlr_pointer_impl" #-} WLR_pointer_impl
+    deriving (Show)
+
+data {-# CTYPE "wlr/types/wlr_pointer.h" "struct wlr_pointer" #-} WLR_pointer
+    = WLR_pointer
+    { wlr_pointer_base :: Ptr WLR_input_device
+    , wlr_pointer_impl :: Ptr WLR_pointer_impl
+    , wlr_pointer_output_name :: Ptr CString
+    --, wlr_pointer_events :: WLR_pointer_events 
+    }
+
+--	char *output_name;
+--
+--	struct {
+--		struct wl_signal motion; // struct wlr_pointer_motion_event
+--		struct wl_signal motion_absolute; // struct wlr_pointer_motion_absolute_event
+--		struct wl_signal button; // struct wlr_pointer_button_event
+--		struct wl_signal axis; // struct wlr_pointer_axis_event
+--		struct wl_signal frame;
+--
+--		struct wl_signal swipe_begin; // struct wlr_pointer_swipe_begin_event
+--		struct wl_signal swipe_update; // struct wlr_pointer_swipe_update_event
+--		struct wl_signal swipe_end; // struct wlr_pointer_swipe_end_event
+--
+--		struct wl_signal pinch_begin; // struct wlr_pointer_pinch_begin_event
+--		struct wl_signal pinch_update; // struct wlr_pointer_pinch_update_event
+--		struct wl_signal pinch_end; // struct wlr_pointer_pinch_end_event
+--
+--		struct wl_signal hold_begin; // struct wlr_pointer_hold_begin_event
+--		struct wl_signal hold_end; // struct wlr_pointer_hold_end_event
+--	} events;
+--
+--	void *data;
+--};

--- a/src/WLR/Types/Pointer.hsc
+++ b/src/WLR/Types/Pointer.hsc
@@ -1,7 +1,6 @@
 {-# LANGUAGE EmptyDataDeriving #-}
 module WLR.Types.Pointer (
     WLR_pointer(..)
-    , WLR_pointer_events(..)
     ) where
 
 #define WLR_USE_UNSTABLE
@@ -31,41 +30,9 @@ data {-# CTYPE "wlr/types/wlr_pointer.h" "struct wlr_pointer" #-} WLR_pointer
     = WLR_pointer
     { wlr_pointer_base :: Ptr WLR_input_device
     , wlr_pointer_impl :: Ptr WLR_pointer_impl
-    , wlr_pointer_output_name :: Ptr CString
-    , wlr_pointer_events :: WLR_pointer_events
-
-    -- TODO what type is this? It's a void* in the C source
-    -- void *data;
-    , wlr_pointer_data :: Ptr ()
-    }
-
-instance Storable WLR_pointer where
-    alignment _ = #alignment struct wlr_pointer
-    sizeOf _ = #size struct wlr_pointer
-    peek ptr = WLR_pointer
-        <$> (#peek struct wlr_pointer, base) ptr
-        <*> (#peek struct wlr_pointer, impl) ptr
-        <*> (#peek struct wlr_pointer, output_name) ptr
-        -- TODO this 'events' attribute isn't actually a pointer in the source
-        -- what should I do?
-        <*> (#peek struct wlr_pointer, events) ptr
-        <*> (#peek struct wlr_pointer, data) ptr
-    poke ptr t = do
-        (#poke struct wlr_pointer, base) ptr $ wlr_pointer_base t
-        (#poke struct wlr_pointer, impl) ptr $ wlr_pointer_impl t
-        (#poke struct wlr_pointer, output_name) ptr $ wlr_pointer_output_name t
-        (#poke struct wlr_pointer, events) ptr $ wlr_pointer_events t
-        (#poke struct wlr_pointer, data) ptr $ wlr_pointer_data t
-
-{- 
- - TODO there were some source comments here that had some sort of struct
- - type specified, I guess it's a hint about the types???
- - I think I did the comment structure so that `struct wlr_pointer_motion_event` will show on hover
- - need to check that when I get my hls working ~ Matt t
--}
-data WLR_pointer_events = WLR_pointer_events {
+    , wlr_pointer_output_name :: CString
     -- |struct wlr_pointer_motion_event
-    wlr_pointer_events_motion :: WL_signal
+    , wlr_pointer_events_motion :: WL_signal
     -- |struct wlr_pointer_motion_absolute_event
     , wlr_pointer_events_motion_absolute :: WL_signal
     -- |struct wlr_pointer_button_event
@@ -92,41 +59,58 @@ data WLR_pointer_events = WLR_pointer_events {
     , wlr_pointer_events_hold_begin :: WL_signal
     -- |struct wlr_pointer_hold_end_event
     , wlr_pointer_events_hold_end :: WL_signal
+
+    , wlr_pointer_data :: Ptr ()
     }
 
-instance Storable WLR_pointer_events where
-    -- Because this 'events' struct is defined within the pointer struct,
-    -- does that mean that I can't use this #alignment???
-    -- I doubt this works, but it compiles without sizeOf and alignment
-    -- maybe I have to use the argument to `alignment` TODO look into that,
-    -- maybe I can use that to tell it where to find the nested struct definition
-    --alignment _ = #alignment struct wlr_pointer.events
-    --sizeOf _ = #size struct wlr_pointer.events
-    peek ptr = WLR_pointer_events
-        <$> (#peek struct wlr_pointer, events.motion) ptr
+instance Storable WLR_pointer where
+    alignment _ = #alignment struct wlr_pointer
+    sizeOf _ = #size struct wlr_pointer
+    peek ptr = WLR_pointer
+        <$> (#peek struct wlr_pointer, base) ptr
+        <*> (#peek struct wlr_pointer, impl) ptr
+        <*> (#peek struct wlr_pointer, output_name) ptr
+
+        <*> (#peek struct wlr_pointer, events.motion) ptr
         <*> (#peek struct wlr_pointer, events.motion_absolute) ptr
+
         <*> (#peek struct wlr_pointer, events.button) ptr
         <*> (#peek struct wlr_pointer, events.axis) ptr
         <*> (#peek struct wlr_pointer, events.frame) ptr
+
         <*> (#peek struct wlr_pointer, events.swipe_begin) ptr
         <*> (#peek struct wlr_pointer, events.swipe_update) ptr
         <*> (#peek struct wlr_pointer, events.swipe_end) ptr
+
         <*> (#peek struct wlr_pointer, events.pinch_begin) ptr
         <*> (#peek struct wlr_pointer, events.pinch_update) ptr
         <*> (#peek struct wlr_pointer, events.pinch_end) ptr
+
         <*> (#peek struct wlr_pointer, events.hold_begin) ptr
         <*> (#peek struct wlr_pointer, events.hold_end) ptr
+
+        <*> (#peek struct wlr_pointer, data) ptr
     poke ptr t = do
+        (#poke struct wlr_pointer, base) ptr $ wlr_pointer_base t
+        (#poke struct wlr_pointer, impl) ptr $ wlr_pointer_impl t
+        (#poke struct wlr_pointer, output_name) ptr $ wlr_pointer_output_name t
+
         (#poke struct wlr_pointer, events.motion) ptr $ wlr_pointer_events_motion t
         (#poke struct wlr_pointer, events.motion_absolute) ptr $ wlr_pointer_events_motion_absolute t
+
         (#poke struct wlr_pointer, events.button) ptr $ wlr_pointer_events_button t
         (#poke struct wlr_pointer, events.axis) ptr $ wlr_pointer_events_axis t
         (#poke struct wlr_pointer, events.frame) ptr $ wlr_pointer_events_frame t
+
         (#poke struct wlr_pointer, events.swipe_begin) ptr $ wlr_pointer_events_swipe_begin t
         (#poke struct wlr_pointer, events.swipe_update) ptr $ wlr_pointer_events_swipe_update t
         (#poke struct wlr_pointer, events.swipe_end) ptr $ wlr_pointer_events_swipe_end t
+
         (#poke struct wlr_pointer, events.pinch_begin) ptr $ wlr_pointer_events_pinch_begin t
         (#poke struct wlr_pointer, events.pinch_update) ptr $ wlr_pointer_events_pinch_update t
         (#poke struct wlr_pointer, events.pinch_end) ptr $ wlr_pointer_events_pinch_end t
+
         (#poke struct wlr_pointer, events.hold_begin) ptr $ wlr_pointer_events_hold_begin t
         (#poke struct wlr_pointer, events.hold_end) ptr $ wlr_pointer_events_hold_end t
+
+        (#poke struct wlr_pointer, data) ptr $ wlr_pointer_data t

--- a/src/WLR/Types/Pointer.hsc
+++ b/src/WLR/Types/Pointer.hsc
@@ -28,7 +28,7 @@ data {-# CTYPE "wlr/types/wlr_pointer.h" "struct wlr_pointer_impl" #-} WLR_point
 
 data {-# CTYPE "wlr/types/wlr_pointer.h" "struct wlr_pointer" #-} WLR_pointer
     = WLR_pointer
-    { wlr_pointer_base :: Ptr WLR_input_device
+    { wlr_pointer_base :: WLR_input_device
     , wlr_pointer_impl :: Ptr WLR_pointer_impl
     , wlr_pointer_output_name :: CString
     -- |struct wlr_pointer_motion_event

--- a/src/WLR/Types/Pointer.hsc
+++ b/src/WLR/Types/Pointer.hsc
@@ -4,6 +4,13 @@ module WLR.Types.Pointer (
 #define WLR_USE_UNSTABLE
 #include <wlr/types/wlr_pointer.h>
 
+import Foreign.Ptr (
+    Ptr
+    )
+import Foreign.C.String (
+    CString
+    )
+
 data {-# CTYPE "wlr/types/wlr_pointer.h" "struct wlr_pointer_impl" #-} WLR_pointer_impl
     deriving (Show)
 

--- a/src/WLR/Types/Pointer.hsc
+++ b/src/WLR/Types/Pointer.hsc
@@ -11,42 +11,77 @@ import Foreign.Ptr (
 import Foreign.C.String (
     CString
     )
+import Foreign.Storable (
+    Storable(..)
+    )
 
 import WLR.Types.InputDevice (
     WLR_input_device
     )
+import WL.ServerCore (
+    WL_signal
+    )
 
 data {-# CTYPE "wlr/types/wlr_pointer.h" "struct wlr_pointer_impl" #-} WLR_pointer_impl
     deriving (Show)
+
+data Wlr_pointer_data
 
 data {-# CTYPE "wlr/types/wlr_pointer.h" "struct wlr_pointer" #-} WLR_pointer
     = WLR_pointer
     { wlr_pointer_base :: Ptr WLR_input_device
     , wlr_pointer_impl :: Ptr WLR_pointer_impl
     , wlr_pointer_output_name :: Ptr CString
-    --, wlr_pointer_events :: WLR_pointer_events 
+    , wlr_pointer_events :: WLR_pointer_events
+
+    -- TODO what type is this? It's a void* in the C source
+    -- void *data;
+    , wlr_pointer_data :: Ptr Wlr_pointer_data
     }
 
---	char *output_name;
---
---	struct {
---		struct wl_signal motion; // struct wlr_pointer_motion_event
---		struct wl_signal motion_absolute; // struct wlr_pointer_motion_absolute_event
---		struct wl_signal button; // struct wlr_pointer_button_event
---		struct wl_signal axis; // struct wlr_pointer_axis_event
---		struct wl_signal frame;
---
---		struct wl_signal swipe_begin; // struct wlr_pointer_swipe_begin_event
---		struct wl_signal swipe_update; // struct wlr_pointer_swipe_update_event
---		struct wl_signal swipe_end; // struct wlr_pointer_swipe_end_event
---
---		struct wl_signal pinch_begin; // struct wlr_pointer_pinch_begin_event
---		struct wl_signal pinch_update; // struct wlr_pointer_pinch_update_event
---		struct wl_signal pinch_end; // struct wlr_pointer_pinch_end_event
---
---		struct wl_signal hold_begin; // struct wlr_pointer_hold_begin_event
---		struct wl_signal hold_end; // struct wlr_pointer_hold_end_event
---	} events;
---
---	void *data;
---};
+instance Storable WLR_pointer where
+    alignment _ = #alignment struct wlr_pointer
+    sizeOf _ = #size struct wlr_pointer
+    peek ptr = WLR_pointer
+        <$> (#peek struct wlr_pointer, base) ptr
+        <*> (#peek struct wlr_pointer, impl) ptr
+        <*> (#peek struct wlr_pointer, output_name) ptr
+        <*> (#peek struct wlr_pointer, events) ptr
+        <*> (#peek struct wlr_pointer, data) ptr
+
+{-# 
+ - TODO there were some source comments here that had some sort of struct
+ - type specified, I guess it's a hint about the types???
+ - I think I did the comment structure so that `struct wlr_pointer_motion_event` will show on hover
+ - need to check that when I get my hls working ~ Matt
+#-}
+data WLR_pointer_events = WLR_pointer_events {
+    -- |struct wlr_pointer_motion_event
+    wlr_pointer_events_motion :: WL_signal
+    -- |struct wlr_pointer_motion_absolute_event
+    , wlr_pointer_events_motion_absolute :: WL_signal
+    -- |struct wlr_pointer_button_event
+    , wlr_pointer_events_button :: WL_signal
+    -- |struct wlr_pointer_axis_event
+    , wlr_pointer_events_axis :: WL_signal
+    , wlr_pointer_events_frame
+
+    -- |struct wlr_pointer_swipe_begin_event
+    , wlr_pointer_events_swipe_begin :: WL_signal
+    -- |struct wlr_pointer_swipe_update_event
+    , wlr_pointer_events_swipe_update :: WL_signal
+    -- |struct wlr_pointer_swipe_end_event
+    , wlr_pointer_events_swipe_end :: WL_signal
+
+    -- |struct wlr_pointer_pinch_begin_event
+    , wlr_pointer_events_pinch_begin :: WL_signal
+    -- |struct wlr_pointer_pinch_update_event
+    , wlr_pointer_events_pinch_update :: WL_signal
+    -- |struct wlr_pointer_pinch_end_event
+    , wlr_pointer_events_pinch_end :: WL_signal
+
+    -- |struct wlr_pointer_hold_begin_event
+    , wlr_pointer_events_hold_begin :: WL_signal
+    -- |struct wlr_pointer_hold_end_event
+    , wlr_pointer_events_hold_end :: WL_signal
+    }

--- a/src/WLR/Types/Pointer.hsc
+++ b/src/WLR/Types/Pointer.hsc
@@ -92,6 +92,8 @@ instance Storable WLR_pointer_events where
     -- Because this 'events' struct is defined within the pointer struct,
     -- does that mean that I can't use this #alignment???
     -- I doubt this works, but it compiles without sizeOf and alignment
+    -- maybe I have to use the argument to `alignment` TODO look into that,
+    -- maybe I can use that to tell it where to find the nested struct definition
     --alignment _ = #alignment struct wlr_pointer.events
     --sizeOf _ = #size struct wlr_pointer.events
     peek ptr = WLR_pointer_events
@@ -108,3 +110,17 @@ instance Storable WLR_pointer_events where
         <*> (#peek struct wlr_pointer, events.pinch_end) ptr
         <*> (#peek struct wlr_pointer, events.hold_begin) ptr
         <*> (#peek struct wlr_pointer, events.hold_end) ptr
+    poke ptr t = do
+        (#poke struct wlr_pointer, events.motion) ptr $ wlr_pointer_events_motion t
+        (#poke struct wlr_pointer, events.motion_absolute) ptr $ wlr_pointer_events_motion_absolute t
+        (#poke struct wlr_pointer, events.button) ptr $ wlr_pointer_events_button t
+        (#poke struct wlr_pointer, events.axis) ptr $ wlr_pointer_events_axis t
+        (#poke struct wlr_pointer, events.frame) ptr $ wlr_pointer_events_frame t
+        (#poke struct wlr_pointer, events.swipe_begin) ptr $ wlr_pointer_events_swipe_begin t
+        (#poke struct wlr_pointer, events.swipe_update) ptr $ wlr_pointer_events_swipe_update t
+        (#poke struct wlr_pointer, events.swipe_end) ptr $ wlr_pointer_events_swipe_end t
+        (#poke struct wlr_pointer, events.pinch_begin) ptr $ wlr_pointer_events_pinch_begin t
+        (#poke struct wlr_pointer, events.pinch_update) ptr $ wlr_pointer_events_pinch_update t
+        (#poke struct wlr_pointer, events.pinch_end) ptr $ wlr_pointer_events_pinch_end t
+        (#poke struct wlr_pointer, events.hold_begin) ptr $ wlr_pointer_events_hold_begin t
+        (#poke struct wlr_pointer, events.hold_end) ptr $ wlr_pointer_events_hold_end t

--- a/src/WLR/Types/Pointer.hsc
+++ b/src/WLR/Types/Pointer.hsc
@@ -91,8 +91,9 @@ data WLR_pointer_events = WLR_pointer_events {
 instance Storable WLR_pointer_events where
     -- Because this 'events' struct is defined within the pointer struct,
     -- does that mean that I can't use this #alignment???
-    -- alignment _ = #alignment struct wlr_pointer.events
-    -- sizeOf _ = #size struct wlr_pointer.events
+    -- I doubt this works, but it compiles without sizeOf and alignment
+    --alignment _ = #alignment struct wlr_pointer.events
+    --sizeOf _ = #size struct wlr_pointer.events
     peek ptr = WLR_pointer_events
         <$> (#peek struct wlr_pointer, events.motion) ptr
         <*> (#peek struct wlr_pointer, events.motion_absolute) ptr
@@ -107,4 +108,3 @@ instance Storable WLR_pointer_events where
         <*> (#peek struct wlr_pointer, events.pinch_end) ptr
         <*> (#peek struct wlr_pointer, events.hold_begin) ptr
         <*> (#peek struct wlr_pointer, events.hold_end) ptr
-

--- a/src/WLR/Types/Pointer.hsc
+++ b/src/WLR/Types/Pointer.hsc
@@ -46,6 +46,8 @@ instance Storable WLR_pointer where
         <$> (#peek struct wlr_pointer, base) ptr
         <*> (#peek struct wlr_pointer, impl) ptr
         <*> (#peek struct wlr_pointer, output_name) ptr
+        -- TODO this 'events' attribute isn't actually a pointer in the source
+        -- what should I do?
         <*> (#peek struct wlr_pointer, events) ptr
         <*> (#peek struct wlr_pointer, data) ptr
 
@@ -64,7 +66,7 @@ data WLR_pointer_events = WLR_pointer_events {
     , wlr_pointer_events_button :: WL_signal
     -- |struct wlr_pointer_axis_event
     , wlr_pointer_events_axis :: WL_signal
-    , wlr_pointer_events_frame
+    , wlr_pointer_events_frame :: WL_signal
 
     -- |struct wlr_pointer_swipe_begin_event
     , wlr_pointer_events_swipe_begin :: WL_signal
@@ -85,3 +87,24 @@ data WLR_pointer_events = WLR_pointer_events {
     -- |struct wlr_pointer_hold_end_event
     , wlr_pointer_events_hold_end :: WL_signal
     }
+
+instance Storable WLR_pointer_events where
+    -- Because this 'events' struct is defined within the pointer struct,
+    -- does that mean that I can't use this #alignment???
+    alignment _ = #alignment struct wlr_pointer.events
+    sizeOf _ = #size struct wlr_pointer.events
+    peek ptr = WLR_pointer
+        <$> (#peek struct wlr_pointer.events, motion) ptr
+        <*> (#peek struct wlr_pointer.events, motion_absolute) ptr
+        <*> (#peek struct wlr_pointer.events, button) ptr
+        <*> (#peek struct wlr_pointer.events, axis) ptr
+        <*> (#peek struct wlr_pointer.events, frame) ptr
+        <*> (#peek struct wlr_pointer.events, swipe_begin) ptr
+        <*> (#peek struct wlr_pointer.events, swipe_update) ptr
+        <*> (#peek struct wlr_pointer.events, swipe_end) ptr
+        <*> (#peek struct wlr_pointer.events, pinch_begin) ptr
+        <*> (#peek struct wlr_pointer.events, pinch_update) ptr
+        <*> (#peek struct wlr_pointer.events, pinch_end) ptr
+        <*> (#peek struct wlr_pointer.events, hold_begin) ptr
+        <*> (#peek struct wlr_pointer.events, hold_end) ptr
+

--- a/wlhs-bindings.cabal
+++ b/wlhs-bindings.cabal
@@ -22,6 +22,7 @@ library
         WLR.Render.DrmFormatSet
         WLR.Render.Renderer
         WLR.Types.Buffer
+        WLR.Types.InputDevice
         WLR.Util.Addon
         WLR.Version
 

--- a/wlhs-bindings.cabal
+++ b/wlhs-bindings.cabal
@@ -23,6 +23,7 @@ library
         WLR.Render.Renderer
         WLR.Types.Buffer
         WLR.Types.InputDevice
+		WLR.Types.Pointer
         WLR.Util.Addon
         WLR.Version
 

--- a/wlhs-bindings.cabal
+++ b/wlhs-bindings.cabal
@@ -23,7 +23,7 @@ library
         WLR.Render.Renderer
         WLR.Types.Buffer
         WLR.Types.InputDevice
-		WLR.Types.Pointer
+        WLR.Types.Pointer
         WLR.Util.Addon
         WLR.Version
 


### PR DESCRIPTION
* it builds with `$ cabal build`
* this branch depends on the WLR_input_device branch which hasn't been merged yet
* I'm not sure how to do the `alignment` and sizeof implementation for the wlr_pointer_events struct, because the struct is defined and used within the wlr_pointer struct
* even though this is probably wrong it could save someone who knows what they're doing some typing
* modified the .gitignore to to hide the `.direnv` directory, which shows up for direnv users
* I commit a lot and the quality of commits isn't great, I usually squash merge to keep that noise out of the history