### PR TITLE
wlr_keyboard.h & wlr_keyboard_group.h files

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ data {-# CTYPE "include.h" "struct wl_type_name" #-} WL_type_name
     wl_type_name,
     field1, Type1,
     field2, Type2,
-    nested field, Type2
+    nested field, Type2,
+    arrayfield, [3]Type3
 }}
 ```
 
@@ -71,6 +72,7 @@ data {-# CTYPE "include.h" "struct wl_type_name" #-} WL_type_name
     { wl_type_name_field1 :: Type1
     , wl_type_name_field2 :: Type2
     , wl_type_name_nested_field :: Type2
+    , wl_type_name_arrayfield :: [Type3]
     } deriving (Show)
     
 instance Storable WL_type_name where
@@ -80,10 +82,12 @@ instance Storable WL_type_name where
         <$> (#peek struct wl_type_name, field1) ptr
         <*> (#peek struct wl_type_name, field2) ptr
         <*> (#peek struct wl_type_name, nested.field) ptr
+        <*> peekArray 3 ((#ptr struct wl_type_name, arrayfield) ptr)
     poke ptr t = do
         (#poke struct wl_type_name, field1) ptr (wl_type_name_field1 t)
         (#poke struct wl_type_name, field2) ptr (wl_type_name_field2 t)
         (#poke struct wl_type_name, nested.field) ptr (wl_type_name_nested_field t)
+        pokeArray ((#ptr struct wl_type_name, nested.field) ptr) (wl_type_name_nested_field t)
 ```
 
 </td>

--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ instance Storable WL_type_name where
         <*> (#peek struct wl_type_name, field2) ptr
         <*> (#peek struct wl_type_name, nested.field) ptr
     poke ptr t = do
-        (#peek struct wl_type_name, field1) ptr (wl_type_name_field1 t)
-        (#peek struct wl_type_name, field2) ptr (wl_type_name_field2 t)
-        (#peek struct wl_type_name, nested.field) ptr (wl_type_name_nested_field t)
+        (#poke struct wl_type_name, field1) ptr (wl_type_name_field1 t)
+        (#poke struct wl_type_name, field2) ptr (wl_type_name_field2 t)
+        (#poke struct wl_type_name, nested.field) ptr (wl_type_name_nested_field t)
 ```
 
 </td>

--- a/src/WL/Keyboard.hsc
+++ b/src/WL/Keyboard.hsc
@@ -1,14 +1,13 @@
 {-# LANGUAGE PatternSynonyms #-}
 module WL.Keyboard where
 
+#include <wayland-server-protocol.h>
+
 import Foreign.C.Types (CInt)
 
--- still not sure I like any CInt working in place of a WL_keyboard_key_state
-type WL_keyboard_key_state = CInt
-
--- not pressed
-pattern WL_KEYBOARD_KEY_STATE_RELEASED :: (Eq a, Num a) => a
-pattern WL_KEYBOARD_KEY_STATE_RELEASED = 0
--- pressed
-pattern WL_KEYBOARD_KEY_STATE_PRESSED :: (Eq a, Num a) => a
-pattern WL_KEYBOARD_KEY_STATE_PRESSED = 1
+{{
+    enum
+    WL_keyboard_key_state,
+    WL_KEYBOARD_KEY_STATE_RELEASED,
+    WL_KEYBOARD_KEY_STATE_PRESSED
+}}

--- a/src/WL/Keyboard.hsc
+++ b/src/WL/Keyboard.hsc
@@ -1,0 +1,14 @@
+{-# LANGUAGE PatternSynonyms #-}
+module WL.Keyboard where
+
+import Foreign.C.Types (CInt)
+
+-- still not sure I like any CInt working in place of a WL_keyboard_key_state
+type WL_keyboard_key_state = CInt
+
+-- not pressed
+pattern WL_KEYBOARD_KEY_STATE_RELEASED :: (Eq a, Num a) => a
+pattern WL_KEYBOARD_KEY_STATE_RELEASED = 0
+-- pressed
+pattern WL_KEYBOARD_KEY_STATE_PRESSED :: (Eq a, Num a) => a
+pattern WL_KEYBOARD_KEY_STATE_PRESSED = 1

--- a/src/WLR/Types/Keyboard.hs-boot
+++ b/src/WLR/Types/Keyboard.hs-boot
@@ -1,0 +1,7 @@
+-- there is an import cycle in the C: wlr_keyboard <-> wlr_keyboard_group
+-- so I either needed to move all of the keyboard group definitions into the
+-- Keyboard.hsc file (yuck), or declare an hs-boot file for Keyboard and
+-- use the SOURCE pragma when keyboard group imports it
+-- I chose the latter, because other work arounds would be less similar to the C source
+module WLR.Types.Keyboard where
+   data WLR_keyboard

--- a/src/WLR/Types/Keyboard.hsc
+++ b/src/WLR/Types/Keyboard.hsc
@@ -5,7 +5,7 @@ module WLR.Types.Keyboard where
 #define WLR_USE_UNSTABLE
 #include <wlr/types/wlr_keyboard.h>
 
-import Foreign (Storable(..))
+import Foreign (Storable(..), Word32, peekArray, pokeArray, plusPtr)
 import Foreign.C.Types (CSize(..), CInt(..), CBool(..), CUInt)
 import Foreign.C.String (CString)
 import Foreign.Ptr (Ptr)
@@ -83,9 +83,6 @@ data {-# CTYPE "wlr/types/wlr_keyboard.h" "struct wlr_keyboard impl" #-} WLR_key
 data XKB_keymap
 data XKB_state
 
--- TODO write this by hand or update the macro to work with arrays
-type ArrayType = ()
-
 {{ struct
     wlr/types/wlr_keyboard.h,
     wlr_keyboard,
@@ -97,10 +94,10 @@ type ArrayType = ()
     keymap_fd, CInt,
     keymap, Ptr XKB_keymap,
     xkb_state, Ptr XKB_state,
-    led_indexes, ArrayType,
-    mod_indexes, ArrayType,
+    led_indexes, [(#const WLR_LED_COUNT)]Word32,
+    mod_indexes, [(#const WLR_MODIFIER_COUNT)]Word32,
     leds, CInt,
-    keycodes, ArrayType,
+    keycodes, [(#const WLR_KEYBOARD_KEYS_CAP)]Word32,
     num_keycodes, CSize,
     modifiers, WLR_keyboard_modifiers,
     repeat_info rate, CUInt,
@@ -111,10 +108,6 @@ type ArrayType = ()
     events repeat_info, WL_signal,
     data, Ptr ()
 }}
-    --remaining array types
-    --xkb_led_index_t led_indexes[WLR_LED_COUNT];
-    --xkb_mod_index_t mod_indexes[WLR_MODIFIER_COUNT];
-    --uint32_t keycodes[WLR_KEYBOARD_KEYS_CAP];
 
 {{ struct
     wlr/types/wlr_keyboard.h,

--- a/src/WLR/Types/Keyboard.hsc
+++ b/src/WLR/Types/Keyboard.hsc
@@ -34,7 +34,7 @@ pattern WLR_LED_SCROLL_LOCK = 4
 pattern WLR_MODIFIER_COUNT :: (Eq a, Num a) => a
 pattern WLR_MODIFIER_COUNT = 8
 
-type Wlr_keyboard_modifier = CInt
+type WLR_keyboard_modifier = CInt
 -- enum wlr_keyboard_modifier {
 -- WLR_MODIFIER_SHIFT = 1 << 0,
 pattern WLR_MODIFIER_SHIFT :: (Eq a, Num a) => a
@@ -80,8 +80,8 @@ data {-# CTYPE "wlr/types/wlr_keyboard.h" "struct wlr_keyboard impl" #-} WLR_key
 
 -- cannot import these types from libxcommon because of their fields which have
 -- internal types that aren't exported
-data Xkb_keymap
-data Xkb_state
+data XKB_keymap
+data XKB_state
 
 -- TODO write this by hand or update the macro to work with arrays
 type ArrayType = ()
@@ -95,8 +95,8 @@ type ArrayType = ()
     keymap_string, CString,
     keymap_size, CSize,
     keymap_fd, CInt,
-    keymap, Ptr Xkb_keymap,
-    xkb_state, Ptr Xkb_state,
+    keymap, Ptr XKB_keymap,
+    xkb_state, Ptr XKB_state,
     led_indexes, ArrayType,
     mod_indexes, ArrayType,
     leds, CInt,
@@ -134,10 +134,10 @@ foreign import capi "wlr/types/wlr_keyboard.h wlr_keyboard_from_input_device"
     wlr_keyboard_from_input_device :: Ptr WLR_input_device -> IO (Ptr WLR_keyboard)
 
 foreign import capi "wlr/types/wlr_keyboard.h wlr_keyboard_set_keymap"
-    wlr_keyboard_set_keymap :: Ptr wLR_keyboard -> Ptr Xkb_keymap -> CBool
+    wlr_keyboard_set_keymap :: Ptr WLR_keyboard -> Ptr XKB_keymap -> CBool
 
 foreign import capi "wlr/types/wlr_keyboard.h wlr_keyboard_keymaps_match"
-    wlr_keyboard_keymaps_match :: Ptr Xkb_keymap -> Ptr Xkb_keymap -> CBool
+    wlr_keyboard_keymaps_match :: Ptr XKB_keymap -> Ptr XKB_keymap -> CBool
 
 {-
  - Set the keyboard repeat info.
@@ -166,4 +166,4 @@ foreign import capi "wlr/types/wlr_keyboard.h wlr_keyboard_led_update"
  - A bitmask of enum wlr_keyboard_modifier is returned.
  -}
 foreign import capi "wlr/types/wlr_keyboard.h wlr_keyboard_get_modifiers"
-    wlr_keyboard_get_modifiers :: Ptr WLR_keyboard -> IO (Wlr_keyboard_modifier)
+    wlr_keyboard_get_modifiers :: Ptr WLR_keyboard -> IO (WLR_keyboard_modifier)

--- a/src/WLR/Types/Keyboard.hsc
+++ b/src/WLR/Types/Keyboard.hsc
@@ -1,0 +1,169 @@
+{-# LANGUAGE EmptyDataDeriving, PatternSynonyms #-}
+
+module WLR.Types.Keyboard where
+
+#define WLR_USE_UNSTABLE
+#include <wlr/types/wlr_keyboard.h>
+
+import Foreign (Word32, Storable(..))
+import Foreign.C.Types (CSize(..), CInt(..), CBool(..))
+import Foreign.C.String (CString)
+import Foreign.Ptr (Ptr)
+
+import WLR.Types.InputDevice (WLR_input_device)
+import WLR.Types.KeyboardGroup (WLR_keyboard_group)
+
+import WL.ServerCore (WL_signal)
+import WL.Keyboard (WL_keyboard_key_state)
+
+pattern WLR_LED_COUNT :: (Eq a, Num a) => a
+pattern WLR_LED_COUNT = #const WLR_LED_COUNT
+
+type WLR_keyboard_led = CInt
+-- enum wlr_keyboard_led
+--WLR_LED_NUM_LOCK = 1 << 0,
+pattern WLR_LED_NUM_LOCK :: (Eq a, Num a) => a
+pattern WLR_LED_NUM_LOCK = 1
+--WLR_LED_CAPS_LOCK = 1 << 1,
+pattern WLR_LED_CAPS_LOCK :: (Eq a, Num a) => a
+pattern WLR_LED_CAPS_LOCK = 2
+--WLR_LED_SCROLL_LOCK = 1 << 2,
+pattern WLR_LED_SCROLL_LOCK :: (Eq a, Num a) => a
+pattern WLR_LED_SCROLL_LOCK = 4
+
+pattern WLR_MODIFIER_COUNT :: (Eq a, Num a) => a
+pattern WLR_MODIFIER_COUNT = 8
+
+type Wlr_keyboard_modifier = CInt
+-- enum wlr_keyboard_modifier {
+-- WLR_MODIFIER_SHIFT = 1 << 0,
+pattern WLR_MODIFIER_SHIFT :: (Eq a, Num a) => a
+pattern WLR_MODIFIER_SHIFT = 1
+-- WLR_MODIFIER_CAPS = 1 << 1,
+pattern WLR_MODIFIER_CAPS :: (Eq a, Num a) => a
+pattern WLR_MODIFIER_CAPS = 2
+-- WLR_MODIFIER_CTRL = 1 << 2,
+pattern WLR_MODIFIER_CTRL :: (Eq a, Num a) => a
+pattern WLR_MODIFIER_CTRL = 4
+-- WLR_MODIFIER_ALT = 1 << 3,
+pattern WLR_MODIFIER_ALT :: (Eq a, Num a) => a
+pattern WLR_MODIFIER_ALT = 8
+-- WLR_MODIFIER_MOD2 = 1 << 4,
+pattern WLR_MODIFIER_MOD2 :: (Eq a, Num a) => a
+pattern WLR_MODIFIER_MOD2 = 16
+-- WLR_MODIFIER_MOD3 = 1 << 5,
+pattern WLR_MODIFIER_MOD3 :: (Eq a, Num a) => a
+pattern WLR_MODIFIER_MOD3 = 32
+-- WLR_MODIFIER_LOGO = 1 << 6,
+pattern WLR_MODIFIER_LOGO :: (Eq a, Num a) => a
+pattern WLR_MODIFIER_LOGO = 64
+-- WLR_MODIFIER_MOD5 = 1 << 7,
+pattern WLR_MODIFIER_MOD5 :: (Eq a, Num a) => a
+pattern WLR_MODIFIER_MOD5 = 128
+
+pattern WLR_KEYBOARD_KEYS_CAP :: (Eq a, Num a) => a
+pattern WLR_KEYBOARD_KEYS_CAP = 32
+
+data {-# CTYPE "wlr/types/wlr_keyboard.h" "struct wlr_keyboard impl" #-} WLR_keyboard_impl
+    deriving (Show)
+
+-- xkbd_mod_mask_t is a type alias for uint32_t
+
+{{ struct
+    wlr/types/wlr_keyboard.h,
+    wlr_keyboard_modifiers,
+    depressed, Word32,
+    latched, Word32,
+    locked, Word32,
+    group, Word32
+}}
+
+-- cannot import these types from libxcommon because of their fields which have
+-- internal types that aren't exported
+data Xkb_keymap
+data Xkb_state
+
+-- TODO write this by hand or update the macro to work with arrays
+type ArrayType = ()
+
+{{ struct
+    wlr/types/wlr_keyboard.h,
+    wlr_keyboard,
+    base, Ptr WLR_input_device,
+    impl, Ptr WLR_keyboard_impl,
+    group , Ptr WLR_keyboard_group,
+    keymap_string, CString,
+    keymap_size, CSize,
+    keymap_fd, CInt,
+    keymap, Ptr Xkb_keymap,
+    xkb_state, Ptr Xkb_state,
+    led_indexes, ArrayType,
+    mod_indexes, ArrayType,
+    leds, CInt,
+    keycodes, ArrayType,
+    num_keycodes, CSize,
+    modifiers, WLR_keyboard_modifiers,
+    repeat_info rate, Word32,
+    repeat_info delay, Word32,
+    events key, WL_signal,
+    events modifiers, WL_signal,
+    events keymap, WL_signal,
+    events repeat_info, WL_signal,
+    data, Ptr ()
+}}
+    --remaining array types
+    --xkb_led_index_t led_indexes[WLR_LED_COUNT];
+    --xkb_mod_index_t mod_indexes[WLR_MODIFIER_COUNT];
+    --uint32_t keycodes[WLR_KEYBOARD_KEYS_CAP];
+
+{{ struct
+    wlr/types/wlr_keyboard.h,
+    wlr_keyboard_key_event,
+    time_msec, Word32,
+    keycode, Word32,
+    update_state, CBool,
+    state, WL_keyboard_key_state
+}}
+
+{-
+ - Get a struct wlr_keyboard from a struct wlr_input_device.
+ -
+ - Asserts that the input device is a keyboard.
+ -}
+foreign import capi "wlr/types/wlr_keyboard.h wlr_keyboard_from_input_device"
+    wlr_keyboard_from_input_device :: Ptr WLR_input_device -> IO (Ptr WLR_keyboard)
+
+foreign import capi "wlr/types/wlr_keyboard.h wlr_keyboard_set_keymap"
+    wlr_keyboard_set_keymap :: Ptr wLR_keyboard -> Ptr Xkb_keymap -> CBool
+
+foreign import capi "wlr/types/wlr_keyboard.h wlr_keyboard_keymaps_match"
+    wlr_keyboard_keymaps_match :: Ptr Xkb_keymap -> Ptr Xkb_keymap -> CBool
+
+{-
+ - Set the keyboard repeat info.
+ -
+ - rate is in key repeats/second and delay is in milliseconds.
+ -
+ - keyboard -> rate -> delay
+ -}
+foreign import capi "wlr/types/wlr_keyboard.h wlr_keyboard_set_repeat_info"
+    wlr_keyboard_set_repeat_info :: Ptr WLR_keyboard -> CInt -> CInt -> IO ()
+
+{-
+ - Update the LEDs on the device, if any.
+ -
+ - leds is a bitmask of enum wlr_keyboard_led.
+ -
+ - If the device doesn't have the provided LEDs, this function is a no-op.
+ -}
+
+foreign import capi "wlr/types/wlr_keyboard.h wlr_keyboard_led_update"
+    wlr_keyboard_led_update :: Ptr WLR_keyboard -> CInt -> IO ()
+
+{-
+ - Get the set of currently depressed or latched modifiers.
+ -
+ - A bitmask of enum wlr_keyboard_modifier is returned.
+ -}
+foreign import capi "wlr/types/wlr_keyboard.h wlr_keyboard_get_modifiers"
+    wlr_keyboard_get_modifiers :: Ptr WLR_keyboard -> IO (Wlr_keyboard_modifier)

--- a/src/WLR/Types/Keyboard.hsc
+++ b/src/WLR/Types/Keyboard.hsc
@@ -5,8 +5,8 @@ module WLR.Types.Keyboard where
 #define WLR_USE_UNSTABLE
 #include <wlr/types/wlr_keyboard.h>
 
-import Foreign (Word32, Storable(..))
-import Foreign.C.Types (CSize(..), CInt(..), CBool(..))
+import Foreign (Storable(..))
+import Foreign.C.Types (CSize(..), CInt(..), CBool(..), CUInt)
 import Foreign.C.String (CString)
 import Foreign.Ptr (Ptr)
 
@@ -72,10 +72,10 @@ data {-# CTYPE "wlr/types/wlr_keyboard.h" "struct wlr_keyboard impl" #-} WLR_key
 {{ struct
     wlr/types/wlr_keyboard.h,
     wlr_keyboard_modifiers,
-    depressed, Word32,
-    latched, Word32,
-    locked, Word32,
-    group, Word32
+    depressed, CUInt,
+    latched, CUInt,
+    locked, CUInt,
+    group, CUInt
 }}
 
 -- cannot import these types from libxcommon because of their fields which have
@@ -103,8 +103,8 @@ type ArrayType = ()
     keycodes, ArrayType,
     num_keycodes, CSize,
     modifiers, WLR_keyboard_modifiers,
-    repeat_info rate, Word32,
-    repeat_info delay, Word32,
+    repeat_info rate, CUInt,
+    repeat_info delay, CUInt,
     events key, WL_signal,
     events modifiers, WL_signal,
     events keymap, WL_signal,
@@ -119,8 +119,8 @@ type ArrayType = ()
 {{ struct
     wlr/types/wlr_keyboard.h,
     wlr_keyboard_key_event,
-    time_msec, Word32,
-    keycode, Word32,
+    time_msec, CUInt,
+    keycode, CUInt,
     update_state, CBool,
     state, WL_keyboard_key_state
 }}

--- a/src/WLR/Types/KeyboardGroup.hsc
+++ b/src/WLR/Types/KeyboardGroup.hsc
@@ -1,0 +1,64 @@
+{-# LANGUAGE EmptyDataDeriving, PatternSynonyms #-}
+
+module WLR.Types.KeyboardGroup where
+
+#define WLR_USE_UNSTABLE
+#include <wlr/types/wlr_keyboard_group.h>
+
+import Foreign.Ptr (Ptr)
+import Foreign.Storable (Storable(..))
+
+import WL.Utils (WL_list)
+import WL.ServerCore (WL_signal)
+import {-# SOURCE #-} WLR.Types.Keyboard (WLR_keyboard)
+
+-- devices :: WL_list keyboard_group_device.link
+-- keys :: WL_list keyboard_group_key.link
+
+-- events enter
+{-
+ - Sent when a keyboard has entered the group with keys currently
+ - pressed that are not pressed by any other keyboard in the group. The
+ - data for this signal will be a struct wl_array containing the key
+ - codes. This should be used to update the compositor's internal state.
+ - Bindings should not be triggered based off of these key codes and
+ - they should also not notify any surfaces of the key press.
+-}
+
+-- events leave
+{-
+ - Sent when a keyboard has left the group with keys currently pressed
+ - that are not pressed by any other keyboard in the group. The data for
+ - this signal will be a struct wl_array containing the key codes. This
+ - should be used to update the compositor's internal state. Bindings
+ - should not be triggered based off of these key codes. Additionally,
+ - surfaces should only be notified if they received a corresponding key
+ - press for the key code.
+-}
+{{ struct
+    wlr/types/wlr_keyboard_group.h,
+    wlr_keyboard_group,
+    keyboard, Ptr WLR_keyboard,
+    devices, WL_list,
+    keys, WL_list,
+    events enter, WL_signal,
+    events leave, WL_signal,
+    data, Ptr ()
+}}
+
+foreign import capi "wlr/types/wlr_keyboard_group.h wlr_keyboard_group_create"
+    wlr_keyboard_group_create :: IO (Ptr WLR_keyboard_group)
+
+foreign import capi "wlr/types/wlr_keyboard_group.h wlr_keyboard_group_from_wlr_keyboard"
+    wlr_keyboard_group_from_wlr_keyboard :: Ptr WLR_keyboard -> Ptr WLR_keyboard_group
+
+-- TODO I looked at the C code for this function and it looks pure, but I'm not sure if it actually is
+-- put it in IO for now
+foreign import capi "wlr/types/wlr_keyboard_group.h wlr_keyboard_group_add_keyboard"
+    wlr_keyboard_group_add_keyboard :: Ptr WLR_keyboard_group -> Ptr WLR_keyboard -> IO (Bool)
+
+foreign import capi "wlr/types/wlr_keyboard_group.h wlr_keyboard_group_remove_keyboard"
+    wlr_keyboard_group_remove_keyboard :: Ptr WLR_keyboard_group -> Ptr WLR_keyboard -> IO ()
+
+foreign import capi "wlr/types/wlr_keyboard_group.h wlr_keyboard_group_destroy"
+    wlr_keyboard_group_destroy :: Ptr WLR_keyboard_group -> IO ()

--- a/src/WLR/Types/Pointer.hsc
+++ b/src/WLR/Types/Pointer.hsc
@@ -72,7 +72,6 @@ import WL.ServerCore (WL_signal)
     WLR_BUTTON_PRESSED
 }}
 
-
 {{ enum
     WLR_axis_source_type,
     WLR_AXIS_SOURCE_WHEEL,

--- a/wlhs-bindings.cabal
+++ b/wlhs-bindings.cabal
@@ -21,6 +21,7 @@ custom-setup
 library
     exposed-modules:
         WL.ServerCore
+        WL.Keyboard
         WL.ServerProtocol
         WL.Utils
         WL.Version
@@ -31,6 +32,8 @@ library
         WLR.Types.Buffer
         WLR.Types.InputDevice
         WLR.Types.Pointer
+        WLR.Types.Keyboard
+        WLR.Types.KeyboardGroup
         WLR.Util.Addon
         WLR.Util.Box
         WLR.Util.Edges


### PR DESCRIPTION
I spent a lot of time trying to figure out how to get the Haskell library `xkbcommon` to build so that I could use its type definitions but no luck. I ended up making the types in wlhs just be opague pointers. (Is that the word? It's just a ptr to an empty data declaration).

If, in order to make a compositor people actually need real peek and poke instances that could be bad.

Similarly, I could not find where the `wl_keyboard_key_state` enum was declared. I can't find the enum declaration in the Wayland library code. I just looked at the names and values of the enum in Wayland's "test/data/example_client.h" and wrote the patterns by hand.

Also, there were some array types in the wlr_keyboard struct, so I just used a dummy type until the macro can support array declarations.