### PR TITLE
Handle array members of structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ instance Storable WL_type_name where
         <*> (#peek struct wl_type_name, field2) ptr
         <*> (#peek struct wl_type_name, nested.field) ptr
     poke ptr t = do
-        (#peek struct wl_type_name, field1) ptr (wl_type_name_field1 t)
-        (#peek struct wl_type_name, field2) ptr (wl_type_name_field2 t)
-        (#peek struct wl_type_name, nested.field) ptr (wl_type_name_nested_field t)
+        (#poke struct wl_type_name, field1) ptr (wl_type_name_field1 t)
+        >> (#poke struct wl_type_name, field2) ptr (wl_type_name_field2 t)
+        >> (#poke struct wl_type_name, nested.field) ptr (wl_type_name_nested_field t)
 ```
 
 </td>

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ data {-# CTYPE "include.h" "struct wl_type_name" #-} WL_type_name
     wl_type_name,
     field1, Type1,
     field2, Type2,
-	array_field[9], [Type2]
+    array_field[9], [Type2]
     nested field, Type2
 }}
 ```
@@ -81,12 +81,12 @@ instance Storable WL_type_name where
     peek ptr = WL_type_name
         <$> (#peek struct wl_type_name, field1) ptr
         <*> (#peek struct wl_type_name, field2) ptr
-		<*> peekArray 9 $ (#ptr struct wl_type_name, array_field) ptr
+        <*> peekArray 9 $ (#ptr struct wl_type_name, array_field) ptr
         <*> (#peek struct wl_type_name, nested.field) ptr
     poke ptr t = do
         (#poke struct wl_type_name, field1) ptr (wl_type_name_field1 t)
         >> (#poke struct wl_type_name, field2) ptr (wl_type_name_field2 t)
-		>> pokeArray ((#ptr wlr_type_name, array_field) ptr) (wlr_type_name_array_field t)
+        >> pokeArray ((#ptr wlr_type_name, array_field) ptr) (wlr_type_name_array_field t)
         >> (#poke struct wl_type_name, nested.field) ptr (wl_type_name_nested_field t)
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ data {-# CTYPE "include.h" "struct wl_type_name" #-} WL_type_name
     wl_type_name,
     field1, Type1,
     field2, Type2,
+	array_field[9], [Type2]
     nested field, Type2
 }}
 ```
@@ -70,6 +71,7 @@ data {-# CTYPE "include.h" "struct wl_type_name" #-} WL_type_name
     = WL_type_name
     { wl_type_name_field1 :: Type1
     , wl_type_name_field2 :: Type2
+    , wl_type_name_array_field :: Type2
     , wl_type_name_nested_field :: Type2
     } deriving (Show)
     
@@ -79,10 +81,12 @@ instance Storable WL_type_name where
     peek ptr = WL_type_name
         <$> (#peek struct wl_type_name, field1) ptr
         <*> (#peek struct wl_type_name, field2) ptr
+		<*> peekArray 9 $ (#ptr struct wl_type_name, array_field) ptr
         <*> (#peek struct wl_type_name, nested.field) ptr
     poke ptr t = do
         (#poke struct wl_type_name, field1) ptr (wl_type_name_field1 t)
         >> (#poke struct wl_type_name, field2) ptr (wl_type_name_field2 t)
+		>> pokeArray ((#ptr wlr_type_name, array_field) ptr) (wlr_type_name_array_field t)
         >> (#poke struct wl_type_name, nested.field) ptr (wl_type_name_nested_field t)
 ```
 


### PR DESCRIPTION
Resolves #11

```
{{ struct
  include.h,
  wlr_example_struct,
  keyboard[9], [CInt],
  output, CString
}}
```
becomes
```
data {-# CTYPE "include.h" "struct wlr_example_struct" #-} WLR_example_struct = WLR_example_struct { wlr_example_struct_keyboard :: [CInt], wlr_example_struct_output :: CString } deriving Show

instance Storable WLR_example_struct where
    alignment _ = #alignment struct wlr_example_struct
    sizeOf _ = #size struct wlr_example_struct
    peek ptr = WLR_example_struct <$> peekArray 9 $ (#ptr wlr_example_struct, keyboard) ptr <*> (#peek struct wlr_example_struct, output) ptr
    poke ptr t = pokeArray ((#ptr wlr_example_struct, keyboard) ptr) (wlr_example_struct_keyboard t) >> (#poke struct wlr_example_struct, output) ptr (wlr_example_struct_output t)
```

~~I've got to run out for a bit, but this PR is missing a corresponding change in the README. I'll try to add that when I get back.~~ Done.

Note: I switched from the `<>` syntax to `T.concat` because it helped with type inference. If you prefer the previous syntax, by all means feel free to edit this PR and change it back.