### PR TITLE
wlr_seat.h

### DIFF
--- a/src/Pixman/Types/Region.hsc
+++ b/src/Pixman/Types/Region.hsc
@@ -1,0 +1,30 @@
+module Pixman.Types.Region where
+
+import Foreign.C.Types (CInt, CLong)
+import Foreign.Storable (Storable(..))
+import Foreign.Ptr (Ptr)
+
+#include <pixman.h>
+
+{{ struct
+    pixman.h,
+    pixman_region32_data,
+    size, CLong,
+    numRects, CLong
+}}
+
+{{ struct
+    pixman.h,
+    pixman_box32,
+    x1, CInt,
+    y1, CInt,
+    x2, CInt,
+    y2, CInt
+}}
+
+{{ struct
+    pixman.h,
+    pixman_region32,
+    extents, PIXMAN_box32,
+    data, Ptr PIXMAN_region32_data
+}}

--- a/src/WL/Client.hs
+++ b/src/WL/Client.hs
@@ -1,0 +1,4 @@
+{-# LANGUAGE EmptyDataDecls #-}
+module WL.Client where
+
+data WL_client

--- a/src/WL/Global.hs
+++ b/src/WL/Global.hs
@@ -1,0 +1,4 @@
+{-# LANGUAGE EmptyDataDecls #-}
+module WL.Global where
+
+data WL_global

--- a/src/WL/ServerCore.hsc
+++ b/src/WL/ServerCore.hsc
@@ -4,6 +4,7 @@ module WL.ServerCore where
 
 import Foreign
 import Foreign.C.String
+import Foreign.Ptr (FunPtr)
 
 import WL.Utils
 import WL.ServerProtocol
@@ -52,3 +53,9 @@ foreign import capi "wayland-server-core.h wl_display_run"
 
 foreign import capi "wayland-server-core.h wl_display_destroy_clients"
     wl_display_destroy_clients :: Ptr WL_display -> IO ()
+
+-- WL_resource isn't importable from wayland, so I think it's meant to be opaque
+data WL_resource
+
+type WL_resource_destroy_func_t = FunPtr (Ptr WL_resource -> IO ())
+--typedef void (*wl_resource_destroy_func_t)(struct wl_resource *resource);

--- a/src/WL/ServerProtocol.hs
+++ b/src/WL/ServerProtocol.hs
@@ -1,3 +1,0 @@
-module WL.ServerProtocol where
-
-data {-# CTYPE "wayland-server-core.h" "struct wl_display" #-} WL_display

--- a/src/WL/ServerProtocol.hsc
+++ b/src/WL/ServerProtocol.hsc
@@ -1,0 +1,34 @@
+{-# LANGUAGE PatternSynonyms #-}
+module WL.ServerProtocol where
+
+#include <wayland-server-protocol.h>
+
+import Foreign.C.Types (CInt)
+
+type WL_data_device_manager_dnd_action = CInt
+
+pattern WL_DATA_DEVICE_MANAGER_DND_ACTION_NONE :: (Eq a, Num a) => a
+pattern WL_DATA_DEVICE_MANAGER_DND_ACTION_NONE = 0
+
+pattern WL_DATA_DEVICE_MANAGER_DND_ACTION_COPY :: (Eq a, Num a) => a
+pattern WL_DATA_DEVICE_MANAGER_DND_ACTION_COPY = 1
+
+pattern WL_DATA_DEVICE_MANAGER_DND_ACTION_MOVE :: (Eq a, Num a) => a
+pattern WL_DATA_DEVICE_MANAGER_DND_ACTION_MOVE = 2
+
+pattern WL_DATA_DEVICE_MANAGER_DND_ACTION_ASK :: (Eq a, Num a) => a
+pattern WL_DATA_DEVICE_MANAGER_DND_ACTION_ASK = 4
+
+data WL_display
+
+{{ enum
+    WL_output_transform,
+    WL_OUTPUT_TRANSFORM_NORMAL,
+    WL_OUTPUT_TRANSFORM_90,
+    WL_OUTPUT_TRANSFORM_180,
+    WL_OUTPUT_TRANSFORM_270,
+    WL_OUTPUT_TRANSFORM_FLIPPED,
+    WL_OUTPUT_TRANSFORM_FLIPPED_90,
+    WL_OUTPUT_TRANSFORM_FLIPPED_180,
+    WL_OUTPUT_TRANSFORM_FLIPPED_270
+}}

--- a/src/WL/Utils.hsc
+++ b/src/WL/Utils.hsc
@@ -4,6 +4,7 @@ module WL.Utils where
 
 import Foreign
 import Foreign.C.Types
+import Foreign.C.String (CString)
 
 {{ struct
     wayland-util.h,
@@ -26,3 +27,30 @@ foreign import capi "wayland-util.h wl_list_length"
 
 foreign import capi "wayland-util.h wl_list_empty"
     wl_list_empty :: Ptr WL_list -> IO CInt
+
+{{ struct
+    wayland-util.h,
+    wl_message,
+    name, CString,
+    signature, CString,
+    types, Ptr (Ptr WL_interface),
+}}
+
+{{ struct
+    wayland-util.h,
+    wl_interface,
+    name, Ptr CChar,
+    version, CInt,
+    method_count, CInt,
+    methods, Ptr WL_message,
+    event_count, CInt,
+    events, Ptr WL_message
+}}
+
+{{ struct
+    wayland-util.h,
+    wl_array,
+    size, CSize,
+    alloc, CSize,
+    data, Ptr ()
+}}

--- a/src/WLR/Render/Texture.hsc
+++ b/src/WLR/Render/Texture.hsc
@@ -1,0 +1,24 @@
+{-# LANGUAGE EmptyDataDeriving #-}
+module WLR.Render.Texture where
+import WLR.Render.Renderer (WLR_renderer)
+
+import Foreign.C.Types (CUInt)
+import Foreign.Ptr (Ptr)
+import Foreign.Storable (Storable(..))
+
+#define WLR_USE_UNSTABLE
+#include <wlr/render/wlr_texture.h>
+
+{{ struct
+    wlr/render/wlr_texture.h,
+    wlr_texture_impl
+}}
+
+{{ struct
+    wlr/render/wlr_texture.h,
+    wlr_texture,
+    impl, Ptr WLR_texture_impl,
+    width, CUInt,
+    height, CUInt,
+    renderer, Ptr WLR_renderer
+}}

--- a/src/WLR/Types/Buffer.hsc
+++ b/src/WLR/Types/Buffer.hsc
@@ -9,7 +9,9 @@ import Foreign
 import Foreign.C.Types
 
 import WL.ServerCore
+
 import WLR.Util.Addon
+import WLR.Render.Texture (WLR_texture)
 
 {{ struct wlr/types/wlr_buffer, wlr_buffer_impl }}
 
@@ -25,4 +27,14 @@ import WLR.Util.Addon
     events destroy, WL_signal,
     events release, WL_signal,
     addons, WLR_addon_set
+}}
+
+{{ struct
+    include/wlr/types/wlr_buffer.h,
+    wlr_client_buffer,
+    base, WLR_buffer,
+    texture, WLR_texture,
+    source, WLR_buffer,
+    source_destroy, WL_listener,
+    n_ignore_locks, CSize,
 }}

--- a/src/WLR/Types/Compositor.hsc
+++ b/src/WLR/Types/Compositor.hsc
@@ -1,0 +1,107 @@
+{-# LANGUAGE PatternSynonyms #-}
+module WLR.Types.Compositor where
+
+import Foreign.C.Types (CBool, CInt, CSize, CUInt)
+import Foreign.C.String (CString)
+import Foreign.Storable (Storable(..))
+import Foreign.Ptr (Ptr, FunPtr)
+
+import WL.Utils (WL_list)
+import WL.ServerCore (WL_resource, WL_signal, WL_listener)
+import WL.ServerProtocol (WL_output_transform)
+
+import WLR.Types.Buffer (WLR_client_buffer, WLR_buffer)
+import WLR.Render.Renderer (WLR_renderer)
+import WLR.Util.Box (WLR_fbox)
+import WLR.Util.Addon (WLR_addon_set)
+
+import Pixman.Types.Region (PIXMAN_region32)
+
+#define WLR_USE_UNSTABLE
+#include <wlr/types/wlr_compositor.h>
+
+-- not exactly sure what int32_t should map to, but I think it's just CInt
+-- some of the fields in wlr_surface had this `int32_t` type
+
+--WLR_surface
+-- the 'resource' field had a source comment, "//may be NULL"
+{{ struct
+    wlr/types/wlr_compositor.h,
+    wlr_surface,
+    resource, Ptr WL_resource,
+    renderer, Ptr WLR_renderer,
+    buffer, WLR_client_buffer,
+    buffer_damage,  PIXMAN_region32,
+    external_damage, PIXMAN_region32,
+    opaque_region, PIXMAN_region32,
+    input_region, PIXMAN_region32,
+    current, WLR_surface_state,
+    pending, WLR_surface_state,
+    cached, WL_list,
+    mapped, CBool,
+    role, Ptr WLR_surface_role,
+    role_resource, Ptr WL_resource,
+    events client_commit, WL_signal,
+    events precommit, WL_signal,
+    events commit, WL_signal,
+    events map, WL_signal,
+    events unmap, WL_signal,
+    events new_subsurface, WL_signal,
+    events destroy, WL_signal,
+    current_outputs, WL_list,
+    addons, WLR_addon_set,
+    renderer_destroy, WL_listener,
+    role_resource_destroy, WL_listener,
+    previous scale, CInt,
+    previous transform, WL_output_transform,
+    previous width, CInt,
+    previous height, CInt,
+    previous buffer_width, CInt,
+    previous buffer_height, CInt,
+    unmap_commit, CBool,
+    opaque, CBool,
+    has_buffer, CBool,
+    preferred_buffer_scale, CInt,
+    preferred_buffer_transform_sent, CBool,
+    preferred_buffer_transform, WL_output_transform
+}}
+
+{{ struct
+    wlr/types/wlr_compositor.h,
+    wlr_surface_state,
+    committed, CUInt,
+    seq, CUInt,
+    buffer, Ptr WLR_buffer,
+    dx, CUInt,
+    dy, CUInt,
+    surface_damage, PIXMAN_region32,
+    buffer_damage, PIXMAN_region32,
+    opaque, PIXMAN_region32,
+    input, PIXMAN_region32,
+    transform, WL_output_transform,
+    scale, CInt,
+    frame_callback_list, WL_list,
+    width, CInt,
+    height, CInt,
+    buffer_width, CInt,
+    buffer_height, CInt,
+    subsurfaces_below, WL_list,
+    subsurfaces_above, WL_list,
+    viewport has_src, CBool,
+    viewport has_dst, CBool,
+    viewport src, WLR_fbox,
+    viewport dst_width, CInt,
+    viewport dst_height, CInt,
+    cached_state_locks, CSize,
+    cached_state_link, WL_list
+}}
+
+{{ struct
+    wlr/types/wlr_compositor.h,
+    wlr_surface_role,
+    name, CString,
+    no_object, CBool,
+    commit, FunPtr (Ptr WLR_surface -> IO ()),
+    unmap, FunPtr (Ptr WLR_surface -> IO ()),
+    destroy, FunPtr (Ptr WLR_surface -> IO())
+}}

--- a/src/WLR/Types/DataDevice.hs-boot
+++ b/src/WLR/Types/DataDevice.hs-boot
@@ -1,0 +1,7 @@
+module WLR.Types.DataDevice (
+    WLR_drag
+    , WLR_data_source
+    ) where
+
+    data WLR_drag
+    data WLR_data_source

--- a/src/WLR/Types/DataDevice.hs-boot
+++ b/src/WLR/Types/DataDevice.hs-boot
@@ -1,3 +1,4 @@
+{-# LANGUAGE EmptyDataDecls #-}
 module WLR.Types.DataDevice (
     WLR_drag
     , WLR_data_source

--- a/src/WLR/Types/DataDevice.hsc
+++ b/src/WLR/Types/DataDevice.hsc
@@ -4,6 +4,7 @@ module WLR.Types.DataDevice where
 #define WLR_USE_UNSTABLE
 #include <wlr/types/wlr_data_device.h>
 
+import Foreign (Word32, Int32)
 import Foreign.Ptr (Ptr)
 import Foreign.C.Types (CUInt, CBool, CInt)
 import Foreign.Storable (Storable(..))
@@ -39,10 +40,10 @@ import WLR.Types.Seat (
     wlr_data_source,
     impl, Ptr WLR_data_source_impl,
     mime_types, WL_array,
-    actions, CUInt,
+    actions, Word32,
     accepted, CBool,
     current_dnd_action, WL_data_device_manager_dnd_action,
-    compositor_action, CUInt,
+    compositor_action, Word32,
     events destroy, WL_signal
 }}
 
@@ -69,7 +70,7 @@ import WLR.Types.Seat (
     started, CBool,
     dropped, CBool,
     cancelling, CBool,
-    grab_touch_id, CUInt,
+    grab_touch_id, Int32,
     touch_id, CUInt,
     events focus, WL_signal,
     events motion, WL_signal,

--- a/src/WLR/Types/DataDevice.hsc
+++ b/src/WLR/Types/DataDevice.hsc
@@ -1,0 +1,74 @@
+{-# LANGUAGE PatternSynonyms #-}
+module WLR.Types.DataDevice where
+
+#define WLR_USE_UNSTABLE
+#include <wlr/types/wlr_data_device.h>
+
+import Foreign.Ptr (Ptr)
+import Foreign.C.Types (CUInt, CBool, CInt)
+import Foreign.Storable (Storable(..))
+
+import WL.Utils (WL_array)
+import WL.ServerProtocol (WL_data_device_manager_dnd_action)
+import WL.ServerCore (WL_signal, WL_listener)
+
+import WLR.Types.Compositor (WLR_surface)
+
+-- TODO break up this import cycle with a hs-boot file
+import WLR.Types.Seat (
+    WLR_seat_keyboard_grab
+    , WLR_seat_pointer_grab
+    , WLR_seat_touch_grab
+    , WLR_seat_client
+    , WLR_seat
+    , WLR_drag_icon
+    )
+
+{{ struct wlr/types/wlr_data_device.h, wlr_data_source_impl }}
+
+{{ struct
+    wlr/types/wlr_data_device.h,
+    wlr_data_source,
+    impl, Ptr WLR_data_source_impl,
+    mime_types, WL_array,
+    actions, CUInt,
+    accepted, CBool,
+    current_dnd_action, WL_data_device_manager_dnd_action,
+    compositor_action, CUInt,
+    events destroy, WL_signal
+}}
+
+{{ enum
+    WLR_drag_grab_type,
+    WLR_DRAG_GRAB_KEYBOARD,
+    WLR_DRAG_GRAB_KEYBOARD_POINTER,
+    WLR_DRAG_GRAB_KEYBOARD_TOUCH
+}}
+
+{{ struct
+    wlr/types/wlr_data_device.h,
+    wlr_drag,
+    grab_type, WLR_drag_grab_type,
+    keyboard_grab, WLR_seat_keyboard_grab,
+    pointer_grab, WLR_seat_pointer_grab,
+    touch_grab, WLR_seat_touch_grab,
+    seat, Ptr WLR_seat,
+    seat_client, Ptr WLR_seat_client,
+    focus_client, Ptr WLR_seat_client,
+    icon, Maybe (Ptr WLR_drag_icon),
+    focus, Maybe (Ptr WLR_surface),
+    source, Maybe (Ptr WLR_data_source),
+    started, CBool,
+    dropped, CBool,
+    cancelling, CBool,
+    grab_touch_id, CUInt,
+    touch_id, CUInt,
+    events focus, WL_signal,
+    events motion, WL_signal,
+    events drop, WL_signal,
+    events destroy, WL_signal,
+    source_destroy, WL_listener,
+    seat_client_destroy, WL_listener,
+    icon_destroy, WL_listener,
+    data, Ptr ()
+}}

--- a/src/WLR/Types/DataDevice.hsc
+++ b/src/WLR/Types/DataDevice.hsc
@@ -14,15 +14,23 @@ import WL.ServerCore (WL_signal, WL_listener)
 
 import WLR.Types.Compositor (WLR_surface)
 
--- TODO break up this import cycle with a hs-boot file
 import WLR.Types.Seat (
     WLR_seat_keyboard_grab
     , WLR_seat_pointer_grab
     , WLR_seat_touch_grab
     , WLR_seat_client
     , WLR_seat
-    , WLR_drag_icon
     )
+
+{{ struct
+    wlr/types/wlr_data_device.h,
+    wlr_drag_icon,
+    drag, Ptr WLR_drag,
+    surface, Ptr WLR_surface,
+    events destroy, WL_signal,
+    surface_destroy, WL_listener,
+    data, Ptr (),
+}}
 
 {{ struct wlr/types/wlr_data_device.h, wlr_data_source_impl }}
 
@@ -55,9 +63,9 @@ import WLR.Types.Seat (
     seat, Ptr WLR_seat,
     seat_client, Ptr WLR_seat_client,
     focus_client, Ptr WLR_seat_client,
-    icon, Maybe (Ptr WLR_drag_icon),
-    focus, Maybe (Ptr WLR_surface),
-    source, Maybe (Ptr WLR_data_source),
+    icon, Ptr WLR_drag_icon,
+    focus, Ptr WLR_surface,
+    source, Ptr WLR_data_source,
     started, CBool,
     dropped, CBool,
     cancelling, CBool,

--- a/src/WLR/Types/KeyboardGroup.hsc
+++ b/src/WLR/Types/KeyboardGroup.hsc
@@ -52,8 +52,6 @@ foreign import capi "wlr/types/wlr_keyboard_group.h wlr_keyboard_group_create"
 foreign import capi "wlr/types/wlr_keyboard_group.h wlr_keyboard_group_from_wlr_keyboard"
     wlr_keyboard_group_from_wlr_keyboard :: Ptr WLR_keyboard -> Ptr WLR_keyboard_group
 
--- TODO I looked at the C code for this function and it looks pure, but I'm not sure if it actually is
--- put it in IO for now
 foreign import capi "wlr/types/wlr_keyboard_group.h wlr_keyboard_group_add_keyboard"
     wlr_keyboard_group_add_keyboard :: Ptr WLR_keyboard_group -> Ptr WLR_keyboard -> IO (Bool)
 

--- a/src/WLR/Types/PrimarySelection.hsc
+++ b/src/WLR/Types/PrimarySelection.hsc
@@ -1,0 +1,21 @@
+module WLR.Types.PrimarySelection where
+
+#define WLR_USE_UNSTABLE
+#include <wlr/types/wlr_primary_selection.h>
+
+import Foreign.Ptr (Ptr)
+import Foreign.Storable (Storable(..))
+
+import WL.Utils (WL_array)
+import WL.ServerCore (WL_signal)
+
+{{ struct wlr/types/wlr_primary_selection.h, wlr_primary_selection_source_impl }}
+
+{{ struct
+    wlr/types/wlr_primary_selection.h,
+    wlr_primary_selection_source,
+    impl, Ptr WLR_primary_selection_source_impl,
+    mime_types, WL_array,
+    events destroy, WL_signal,
+    data, Ptr ()
+}}

--- a/src/WLR/Types/Seat.hsc
+++ b/src/WLR/Types/Seat.hsc
@@ -7,12 +7,12 @@ module WLR.Types.Seat where
 #include <time.h>
 
 import Foreign.C.String (CString)
-import Foreign.C.Types (CUInt, CDouble, CInt, CBool, CSize)
+import Foreign.C.Types (CDouble, CInt, CBool, CSize)
 -- if we upgrade our base libraries we can use this
 -- https://github.com/haskell/core-libraries-committee/issues/118
 -- import Foreign.C.ConstPtr
 import Foreign.Ptr (Ptr, FunPtr)
-import Foreign (peekArray, pokeArray, plusPtr)
+import Foreign (peekArray, pokeArray, plusPtr, Word32, Int32)
 import Foreign.Storable (Storable(..))
 
 import WL.ServerProtocol (WL_display)
@@ -38,8 +38,8 @@ import WLR.Types.Keyboard (WLR_keyboard, WLR_keyboard_modifiers)
 {{ struct
     wlr/types/wlr_seat.h,
     wlr_serial_range,
-    min_incl, CUInt,
-    max_incl, CUInt
+    min_incl, Word32,
+    max_incl, Word32
 }}
 
 pattern WLR_SERIAL_RINGSET_SIZE :: (Eq a, Num a) => a
@@ -67,8 +67,8 @@ pattern WLR_SERIAL_RINGSET_SIZE = 128
     events destroy, WL_signal,
     serials, WLR_serial_ringset,
     needs_touch_frame, CBool,
-    value120 acc_discrete, [2] CInt,
-    value120 last_discrete, [2] CInt,
+    value120 acc_discrete, [2] Int32,
+    value120 last_discrete, [2] Int32,
     value120 acc_axis, [2] CDouble,
 }}
 
@@ -77,9 +77,9 @@ pattern WLR_SERIAL_RINGSET_SIZE = 128
     wlr_pointer_grab_interface,
     enter, FunPtr (Ptr WLR_seat_pointer_grab -> Ptr WLR_surface -> CDouble -> CDouble -> IO ()),
     clear_focus, FunPtr (Ptr WLR_seat_pointer_grab -> IO ()),
-    motion, FunPtr (Ptr WLR_seat_pointer_grab -> CUInt -> CDouble -> CDouble -> ()),
-    button, FunPtr (Ptr WLR_seat_pointer_grab -> CUInt -> CUInt -> WLR_button_state_type -> IO (CUInt)),
-    axis, FunPtr (Ptr WLR_seat_pointer_grab -> CUInt -> WLR_axis_orientation_type -> CDouble -> CInt -> WLR_axis_source_type -> IO ()),
+    motion, FunPtr (Ptr WLR_seat_pointer_grab -> Word32 -> CDouble -> CDouble -> ()),
+    button, FunPtr (Ptr WLR_seat_pointer_grab -> Word32 -> Word32 -> WLR_button_state_type -> IO (Word32)),
+    axis, FunPtr (Ptr WLR_seat_pointer_grab -> Word32 -> WLR_axis_orientation_type -> CDouble -> Int32 -> WLR_axis_source_type -> IO ()),
     frame, FunPtr (Ptr WLR_seat_pointer_grab -> IO ()),
     cancel, FunPtr (Ptr WLR_seat_pointer_grab -> IO ())
 }}
@@ -107,11 +107,11 @@ pattern WLR_POINTER_BUTTONS_CAP = 16
     default_grab, Ptr WLR_seat_pointer_grab,
     sent_axis_source, CBool,
     cached_axis_source, WLR_axis_source_type,
-    buttons, [WLR_POINTER_BUTTONS_CAP] CUInt,
+    buttons, [WLR_POINTER_BUTTONS_CAP] Word32,
     button_count, CSize,
-    grab_button, CUInt,
-    grab_serial, CUInt,
-    grab_time, CUInt,
+    grab_button, Word32,
+    grab_serial, Word32,
+    grab_time, Word32,
     surface_destroy, WL_listener,
     events focus_change, WL_signal,
 }}
@@ -137,8 +137,8 @@ pattern WLR_POINTER_BUTTONS_CAP = 16
     wlr_seat_touch_state,
     seat, Ptr WLR_seat,
     touch_points, WL_list,
-    grab_serial, CUInt,
-    grab_id, CUInt,
+    grab_serial, Word32,
+    grab_id, Word32,
     grab, Ptr WLR_seat_touch_grab,
     default_grab, Ptr WLR_seat_touch_grab,
 }}
@@ -150,17 +150,17 @@ pattern WLR_POINTER_BUTTONS_CAP = 16
     display, Ptr WL_display,
     clients, Ptr WL_list,
     name, CString,
-    capabilities, CUInt,
-    accumulated_capabilities, CUInt,
+    capabilities, Word32,
+    accumulated_capabilities, Word32,
     last_event, TIMESPEC,
     selection_source, Ptr WLR_data_source,
-    selection_serial, CUInt,
+    selection_serial, Word32,
     selection_offers, WL_list,
     primary_selection_source, Ptr WLR_primary_selection_source,
-    primary_selection_serial, CUInt,
+    primary_selection_serial, Word32,
     drag, Ptr WLR_drag,
     drag_source, Ptr WLR_data_source,
-    drag_serial, CUInt,
+    drag_serial, Word32,
     drag_offers, WL_list,
     pointer_state, WLR_seat_pointer_state,
     keyboard_state, WLR_seat_keyboard_state,
@@ -189,7 +189,7 @@ pattern WLR_POINTER_BUTTONS_CAP = 16
 {{ struct
     wlr/types/seat.h,
     wlr_touch_point,
-    touch_id, CUInt,
+    touch_id, Int32,
     surface, Ptr WLR_surface,
     client, Ptr WLR_seat_client,
     focus_surface, Ptr WLR_surface,
@@ -215,15 +215,15 @@ pattern WLR_POINTER_BUTTONS_CAP = 16
     data, Ptr ()
 }}
 
--- TODO enter's CUInt final parameter is a const array
+-- TODO enter's Word32 final parameter is a const array
 -- how do I do 'const' in HSC?
 
 {{ struct
     wlr/types/wlr_seat.h,
     wlr_keyboard_grab_interface,
-    enter, FunPtr (Ptr WLR_seat_keyboard_grab -> Ptr WLR_surface -> [] CUInt -> IO ()),
+    enter, FunPtr (Ptr WLR_seat_keyboard_grab -> Ptr WLR_surface -> [] Word32 -> IO ()),
     clear_focus, FunPtr (Ptr WLR_seat_keyboard_grab -> IO ()),
-    key, FunPtr (Ptr WLR_seat_keyboard_grab -> CUInt -> CUInt -> CUInt -> IO ()),
+    key, FunPtr (Ptr WLR_seat_keyboard_grab -> Word32 -> Word32 -> Word32 -> IO ()),
     modifiers, FunPtr (Ptr WLR_seat_keyboard_grab -> Ptr WLR_keyboard_modifiers -> IO ()),
     cancel, FunPtr (Ptr WLR_seat_keyboard_grab -> IO ())
 }}
@@ -231,10 +231,10 @@ pattern WLR_POINTER_BUTTONS_CAP = 16
 {{ struct
     wlr/types/wlr_seat.h,
     wlr_touch_grab_interface,
-    down, FunPtr (Ptr WLR_seat_touch_grab -> CUInt -> Ptr WLR_touch_point -> IO (CUInt)),
-    up, FunPtr (Ptr WLR_seat_touch_grab -> CUInt -> Ptr WLR_touch_point -> IO ()),
-    motion, FunPtr (Ptr WLR_seat_touch_grab -> CUInt -> Ptr WLR_touch_point -> IO ()),
-    enter, FunPtr (Ptr WLR_seat_touch_grab -> CUInt -> Ptr WLR_touch_point -> IO ()),
+    down, FunPtr (Ptr WLR_seat_touch_grab -> Word32 -> Ptr WLR_touch_point -> IO (Word32)),
+    up, FunPtr (Ptr WLR_seat_touch_grab -> Word32 -> Ptr WLR_touch_point -> IO ()),
+    motion, FunPtr (Ptr WLR_seat_touch_grab -> Word32 -> Ptr WLR_touch_point -> IO ()),
+    enter, FunPtr (Ptr WLR_seat_touch_grab -> Word32 -> Ptr WLR_touch_point -> IO ()),
     frame, FunPtr (Ptr WLR_seat_touch_grab -> IO ()),
     cancel, FunPtr (Ptr WLR_seat_touch_grab -> IO()),
     wl_cancel, FunPtr (Ptr WLR_seat_touch_grab -> Ptr WLR_surface -> IO ())

--- a/src/WLR/Types/Seat.hsc
+++ b/src/WLR/Types/Seat.hsc
@@ -7,7 +7,7 @@ module WLR.Types.Seat where
 #include <time.h>
 
 import Foreign.C.String (CString)
-import Foreign.C.Types (CDouble, CInt, CBool, CSize)
+import Foreign.C.Types (CDouble(..), CInt(..), CBool, CSize, CBool(..))
 -- if we upgrade our base libraries we can use this
 -- https://github.com/haskell/core-libraries-committee/issues/118
 -- import Foreign.C.ConstPtr
@@ -248,3 +248,178 @@ pattern WLR_POINTER_BUTTONS_CAP = 16
     data, Ptr ()
 }}
 
+{{ struct
+    wlr/types/seat.h,
+    wlr_seat_pointer_request_set_cursor_event,
+    seat_client, Ptr WLR_seat_client,
+    surface, Ptr WLR_surface,
+    serial, Word32,
+    hotspot_x, Int32,
+    hotspot_y, Int32
+}}
+
+{{ struct
+    wlr/types/seat.h,
+    wlr_seat_request_set_selection_event,
+    source, Ptr WLR_data_source,
+    serial, Word32
+}}
+
+{{ struct wlr/types/seat.h,
+    wlr_seat_request_set_primary_selection_event,
+    source, Ptr WLR_primary_selection_source,
+    serial, Word32
+}}
+
+{{ struct wlr/types/seat.h,
+    wlr_seat_request_start_drag_event,
+    drag, Ptr WLR_drag,
+    origin, Ptr WLR_surface,
+    serial, Word32
+}}
+
+{{ struct wlr/types/seat.h,
+    wlr_seat_pointer_focus_change_event,
+    seat, Ptr WLR_seat,
+    old_surface, Ptr WLR_surface,
+    new_surface, Ptr WLR_surface,
+    sx, CDouble,
+    sy, CDouble
+}}
+{{ struct wlr/types/seat.h,
+    wlr_seat_keyboard_focus_change_event,
+    seat, Ptr WLR_seat,
+    old_surface, Ptr WLR_surface,
+    new_surface, Ptr WLR_surface,
+}}
+
+{-
+ - Allocates a new struct wlr_seat and adds a wl_seat global to the display.
+ -}
+foreign import capi "wlr/types/wlr_seat.h wlr_seat_create"
+    wlr_seat_create :: Ptr WL_display -> CString -> IO (Ptr WLR_seat)
+
+{-
+ - Destroys a seat, removes its wl_seat global and clears focus for all
+ - devices belonging to the seat.
+ -}
+foreign import capi "wlr/types/wlr_seat.h wlr_seat_destroy"
+    wlr_seat_destroy :: Ptr WLR_seat -> IO ()
+
+{-
+ - Gets a struct wlr_seat_client for the specified client, or returns NULL if no
+ - client is bound for that client.
+ -}
+foreign import capi "wlr/types/wlr_seat.h wlr_seat_client_for_wl_client"
+    wlr_seat_client_for_wl_client :: Ptr WLR_seat -> Ptr WL_client -> IO (Ptr WLR_seat_client)
+
+{-
+ - Updates the capabilities available on this seat.
+ - Will automatically send them to all clients.
+ -}
+foreign import capi "wlr/types/wlr_seat.h wlr_seat_set_capabilities"
+    wlr_seat_set_capabilities :: Ptr WLR_seat -> Word32 -> IO ()
+
+--wlr_seat_set_name
+{-
+ - Updates the name of this seat.
+ - Will automatically send it to all clients.
+ -}
+foreign import capi "wlr/types/wlr_seat.h wlr_seat_set_name"
+    wlr_seat_set_name :: Ptr WLR_seat -> CString -> IO ()
+
+{-
+ - Whether or not the surface has pointer focus
+ -}
+foreign import capi "wlr/types/wlr_seat.h wlr_seat_pointer_surface_has_focus"
+    wlr_seat_pointer_surface_has_focus :: Ptr WLR_seat -> Ptr WLR_surface -> IO CBool
+
+{-
+ - Send a pointer enter event to the given surface and consider it to be the
+ - focused surface for the pointer. This will send a leave event to the last
+ - surface that was entered. Coordinates for the enter event are surface-local.
+ - This function does not respect pointer grabs: you probably want
+ - wlr_seat_pointer_notify_enter() instead.
+ -}
+foreign import capi "wlr/types/wlr_seat.h wlr_seat_pointer_enter"
+    wlr_seat_pointer_enter :: Ptr WLR_seat -> Ptr WLR_surface -> CDouble -> CDouble -> IO ()
+
+{-
+ - Clear the focused surface for the pointer and leave all entered surfaces.
+ - This function does not respect pointer grabs: you probably want
+ - wlr_seat_pointer_notify_clear_focus() instead.
+ -}
+foreign import capi "wlr/types/wlr_seat.h wlr_seat_pointer_clear_focus"
+    wlr_seat_pointer_clear_focus :: Ptr WLR_seat -> IO ()
+
+{-
+ - Send a motion event to the surface with pointer focus. Coordinates for the
+ - motion event are surface-local. This function does not respect pointer grabs:
+ - you probably want wlr_seat_pointer_notify_motion() instead.
+ -}
+foreign import capi "wlr/types/wlr_seat.h wlr_seat_pointer_send_motion"
+    wlr_seat_pointer_send_motion :: Ptr WLR_seat -> Word32 -> CDouble -> CDouble -> IO ()
+
+{-
+ - Send a button event to the surface with pointer focus. Coordinates for the
+ - button event are surface-local. Returns the serial. This function does not
+ - respect pointer grabs: you probably want wlr_seat_pointer_notify_button()
+ - instead.
+ -}
+foreign import capi "wlr/types/wlr_seat.h wlr_seat_pointer_send_button"
+    wlr_seat_pointer_send_button :: Ptr WLR_seat -> Word32 -> Word32 -> WLR_button_state_type -> IO Word32
+
+{-
+ - Send an axis event to the surface with pointer focus. This function does not
+ - respect pointer grabs: you probably want wlr_seat_pointer_notify_axis()
+ - instead.
+ -}
+foreign import capi "wlr/types/wlr_seat.h wlr_seat_pointer_send_axis"
+    wlr_seat_pointer_send_axis :: Ptr WLR_seat -> Word32 -> WLR_axis_orientation_type -> CDouble -> Int32 -> WLR_axis_source_type -> IO ()
+
+{-
+ - Send a frame event to the surface with pointer focus. This function does not
+ - respect pointer grabs: you probably want wlr_seat_pointer_notify_frame()
+ - instead.
+ -}
+foreign import capi "wlr/types/wlr_seat.h wlr_seat_pointer_send_frame"
+    wlr_seat_pointer_send_frame :: Ptr WLR_seat -> IO ()
+
+{-
+ - Notify the seat of a pointer enter event to the given surface and request it
+ - to be the focused surface for the pointer. Pass surface-local coordinates
+ - where the enter occurred. This will send a leave event to the currently-
+ - focused surface. Defers to any grab of the pointer.
+ -}
+foreign import capi "wlr/types/wlr_seat.h wlr_seat_pointer_notify_enter"
+    wlr_seat_pointer_notify_enter :: Ptr WLR_seat -> Ptr WLR_surface -> CDouble -> CDouble -> IO ()
+
+{-
+ - Notify the seat of a pointer leave event to the currently-focused surface.
+ - Defers to any grab of the pointer.
+ -}
+foreign import capi "wlr/types/wlr_seat.h wlr_seat_pointer_notify_clear_focus"
+    wlr_seat_pointer_notify_clear_focus :: Ptr WLR_seat -> IO ()
+
+{-
+ - Warp the pointer of this seat to the given surface-local coordinates, without
+ - generating motion events.
+ -}
+foreign import capi "wlr/types/wlr_seat.h wlr_seat_pointer_warp"
+    wlr_seat_pointer_warp :: Ptr WLR_seat -> CDouble -> CDouble -> IO ()
+
+{-
+ - Notify the seat of motion over the given surface. Pass surface-local
+ - coordinates where the pointer motion occurred. Defers to any grab of the
+ - pointer.
+ -}
+foreign import capi "wlr/types/wlr_seat.h wlr_seat_pointer_notify_motion"
+    wlr_seat_pointer_notify_motion :: Ptr WLR_seat -> Word32 -> CDouble -> CDouble -> IO ()
+
+{-
+ - Notify the seat that a button has been pressed. Returns the serial of the
+ - button press or zero if no button press was sent. Defers to any grab of the
+ - pointer.
+ -}
+foreign import capi "wlr/types/wlr_seat.h wlr_seat_pointer_notify_button"
+    wlr_seat_pointer_notify_button :: Ptr WLR_seat -> Word32 -> Word32 -> WLR_button_state_type -> IO Word32

--- a/src/WLR/Types/Seat.hsc
+++ b/src/WLR/Types/Seat.hsc
@@ -1,12 +1,12 @@
 module WLR.Types.Seat where
 
-#include <time.h>
 
 #define WLR_USE_UNSTABLE
 #include <wlr/types/wlr_seat.h>
+#include <time.h>
 
 import Foreign.C.String (CString)
-import Foreign.C.Types (CUInt, CDouble, CInt, CBool)
+import Foreign.C.Types (CUInt, CDouble, CInt, CBool, CSize)
 -- if we upgrade our base libraries we can use this
 -- https://github.com/haskell/core-libraries-committee/issues/118
 -- import Foreign.C.ConstPtr
@@ -19,9 +19,19 @@ import WL.Global (WL_global)
 import WL.Client (WL_client)
 import WL.Utils (WL_list)
 
---import {-# SOURCE #-} WLR.Types.DataDevice (WLR_drag, WLR_data_source)
+import WLR.Util.Time (TIMESPEC)
+import {-# SOURCE #-} WLR.Types.DataDevice (
+    WLR_drag
+    , WLR_data_source
+    )
 import WLR.Types.PrimarySelection (WLR_primary_selection_source)
 import WLR.Types.Compositor (WLR_surface)
+import WLR.Types.Pointer (
+    WLR_axis_source_type
+    , WLR_button_state_type
+    , WLR_axis_orientation_type
+    )
+import WLR.Types.Keyboard (WLR_keyboard, WLR_keyboard_modifiers)
 
 type TODOArray = Ptr ()
 
@@ -66,9 +76,21 @@ type TODOArray = Ptr ()
 }}
 
 {{ struct
+    wlr/types/seat.h,
+    wlr_pointer_grab_interface,
+    enter, FunPtr (Ptr WLR_seat_pointer_grab -> Ptr WLR_surface -> CDouble -> CDouble -> IO ()),
+    clear_focus, FunPtr (Ptr WLR_seat_pointer_grab -> IO ()),
+    motion, FunPtr (Ptr WLR_seat_pointer_grab -> CUInt -> CDouble -> CDouble -> ()),
+    button, FunPtr (Ptr WLR_seat_pointer_grab -> CUInt -> CUInt -> WLR_button_state_type -> IO (CUInt)),
+    axis, FunPtr (Ptr WLR_seat_pointer_grab -> CUInt -> WLR_axis_orientation_type -> CDouble -> CInt -> WLR_axis_source_type -> IO ()),
+    frame, FunPtr (Ptr WLR_seat_pointer_grab -> IO ()),
+    cancel, FunPtr (Ptr WLR_seat_pointer_grab -> IO ())
+}}
+
+{{ struct
     wlr/types/wlr_seat.h,
     wlr_seat_pointer_grab,
-    interface, Ptr wlr_pointer_grab_interface,
+    interface, Ptr WLR_pointer_grab_interface,
     seat, Ptr WLR_seat,
     data, Ptr ()
 }}
@@ -85,7 +107,7 @@ type TODOArray = Ptr ()
     grab, Ptr WLR_seat_pointer_grab,
     default_grab, Ptr WLR_seat_pointer_grab,
     sent_axis_source, CBool,
-    cached_axis_source, WLR_axis_source,
+    cached_axis_source, WLR_axis_source_type,
     buttons, TODOArray,
     button_count, CSize,
     grab_button, CUInt,
@@ -131,7 +153,7 @@ type TODOArray = Ptr ()
     name, CString,
     capabilities, CUInt,
     accumulated_capabilities, CUInt,
-    last_event, timespec,
+    last_event, TIMESPEC,
     selection_source, Ptr WLR_data_source,
     selection_serial, CUInt,
     selection_offers, WL_list,
@@ -165,6 +187,23 @@ type TODOArray = Ptr ()
     data, Ptr ()
 }}
 
+{{ struct
+    wlr/types/seat.h,
+    wlr_touch_point,
+    touch_id, CUInt,
+    surface, Ptr WLR_surface,
+    client, Ptr WLR_seat_client,
+    focus_surface, Ptr WLR_surface,
+    focus_client, Ptr WLR_seat_client,
+    sx, CDouble,
+    sy, CDouble,
+    surface_destroy, WL_listener,
+    focus_surface_destroy, WL_listener,
+    client_destroy, WL_listener,
+    events destroy, WL_signal,
+    link, WL_list
+}}
+
 -- TODO interface was a ConstPtr
 
 {{ struct
@@ -186,3 +225,24 @@ type TODOArray = Ptr ()
     modifiers, FunPtr (Ptr WLR_seat_keyboard_grab -> Ptr WLR_keyboard_modifiers -> IO ()),
     cancel, FunPtr (Ptr WLR_seat_keyboard_grab -> IO ())
 }}
+
+{{ struct
+    wlr/types/wlr_seat.h,
+    wlr_touch_grab_interface,
+    down, FunPtr (Ptr WLR_seat_touch_grab -> CUInt -> Ptr WLR_touch_point -> IO (CUInt)),
+    up, FunPtr (Ptr WLR_seat_touch_grab -> CUInt -> Ptr WLR_touch_point -> IO ()),
+    motion, FunPtr (Ptr WLR_seat_touch_grab -> CUInt -> Ptr WLR_touch_point -> IO ()),
+    enter, FunPtr (Ptr WLR_seat_touch_grab -> CUInt -> Ptr WLR_touch_point -> IO ()),
+    frame, FunPtr (Ptr WLR_seat_touch_grab -> IO ()),
+    cancel, FunPtr (Ptr WLR_seat_touch_grab -> IO()),
+    wl_cancel, FunPtr (Ptr WLR_seat_touch_grab -> Ptr WLR_surface -> IO ())
+}}
+
+{{ struct
+    wlr/types/seat.h,
+    wlr_seat_touch_grab,
+    interface, Ptr WLR_touch_grab_interface,
+    seat, Ptr WLR_seat,
+    data, Ptr ()
+}}
+

--- a/src/WLR/Types/Seat.hsc
+++ b/src/WLR/Types/Seat.hsc
@@ -1,0 +1,188 @@
+module WLR.Types.Seat where
+
+#include <time.h>
+
+#define WLR_USE_UNSTABLE
+#include <wlr/types/wlr_seat.h>
+
+import Foreign.C.String (CString)
+import Foreign.C.Types (CUInt, CDouble, CInt, CBool)
+-- if we upgrade our base libraries we can use this
+-- https://github.com/haskell/core-libraries-committee/issues/118
+-- import Foreign.C.ConstPtr
+import Foreign.Ptr (Ptr, FunPtr)
+import Foreign.Storable (Storable(..))
+
+import WL.ServerProtocol (WL_display)
+import WL.ServerCore (WL_signal, WL_listener)
+import WL.Global (WL_global)
+import WL.Client (WL_client)
+import WL.Utils (WL_list)
+
+--import {-# SOURCE #-} WLR.Types.DataDevice (WLR_drag, WLR_data_source)
+import WLR.Types.PrimarySelection (WLR_primary_selection_source)
+import WLR.Types.Compositor (WLR_surface)
+
+type TODOArray = Ptr ()
+
+{{ struct
+    wlr/types/wlr_seat.h,
+    wlr_serial_range,
+    min_incl, CUInt,
+    max_incl, CUInt
+}}
+
+{{ struct
+    wlr/types/wlr_seat.h,
+    wlr_serial_ringset,
+    data, TODOArray,
+    end, CInt,
+    count, CInt
+}}
+
+-- TODO arrays
+--struct {
+--    int32_t acc_discrete[2];
+--    int32_t last_discrete[2];
+--    double acc_axis[2];
+--} value120;
+{{ struct
+    wlr/types/wlr_seat.h,
+    wlr_seat_client,
+    client, Ptr WL_client,
+    seat, Ptr WLR_seat,
+    link, WL_list,
+    resources, WL_list,
+    pointers, WL_list,
+    keyboards, WL_list,
+    touches, WL_list,
+    data_devices, WL_list,
+    events destroy, WL_signal,
+    serials, WLR_serial_ringset,
+    needs_touch_frame, CBool,
+    value120 acc_discrete, TODOArray,
+    value120 last_discrete, TODOArray,
+    value120 acc_axis, TODOArray,
+}}
+
+{{ struct
+    wlr/types/wlr_seat.h,
+    wlr_seat_pointer_grab,
+    interface, Ptr wlr_pointer_grab_interface,
+    seat, Ptr WLR_seat,
+    data, Ptr ()
+}}
+
+-- TODO array type uint32_t buttons[WLR_POINTER_BUTTONS_CAP];
+{{ struct
+    wlr/types/wlr_seat.h,
+    wlr_seat_pointer_state,
+    seat, Ptr WLR_seat,
+    focused_client, Ptr WLR_seat_client,
+    focused_surface, Ptr WLR_surface,
+    sx, CDouble,
+    sy, CDouble,
+    grab, Ptr WLR_seat_pointer_grab,
+    default_grab, Ptr WLR_seat_pointer_grab,
+    sent_axis_source, CBool,
+    cached_axis_source, WLR_axis_source,
+    buttons, TODOArray,
+    button_count, CSize,
+    grab_button, CUInt,
+    grab_serial, CUInt,
+    grab_time, CUInt,
+    surface_destroy, WL_listener,
+    events focus_change, WL_signal,
+}}
+
+{{ struct
+    wlr/types/wlr_seat.h,
+    wlr_seat_keyboard_state,
+    seat, Ptr WLR_seat,
+    keyboard, Ptr WLR_keyboard,
+    focused_client, Ptr WLR_seat_client,
+    focused_surface, Ptr WLR_surface,
+    keyboard_destroy, WL_listener,
+    keyboard_keymap, WL_listener,
+    keyboard_repeat_info, WL_listener,
+    surface_destroy, WL_listener,
+    grab, Ptr WLR_seat_keyboard_grab,
+    default_grab, Ptr WLR_seat_keyboard_grab,
+    events focus_change, WL_signal,
+}}
+
+{{ struct
+    wlr/types/wlr_seat.h,
+    wlr_seat_touch_state,
+    seat, Ptr WLR_seat,
+    touch_points, WL_list,
+    grab_serial, CUInt,
+    grab_id, CUInt,
+    grab, Ptr WLR_seat_touch_grab,
+    default_grab, Ptr WLR_seat_touch_grab,
+}}
+
+{{ struct
+    wlr/types/wlr_seat.h,
+    wlr_seat,
+    global, Ptr WL_global,
+    display, Ptr WL_display,
+    clients, Ptr WL_list,
+    name, CString,
+    capabilities, CUInt,
+    accumulated_capabilities, CUInt,
+    last_event, timespec,
+    selection_source, Ptr WLR_data_source,
+    selection_serial, CUInt,
+    selection_offers, WL_list,
+    primary_selection_source, Ptr WLR_primary_selection_source,
+    primary_selection_serial, CUInt,
+    drag, Ptr WLR_drag,
+    drag_source, Ptr WLR_data_source,
+    drag_serial, CUInt,
+    drag_offers, WL_list,
+    pointer_state, WLR_seat_pointer_state,
+    keyboard_state, WLR_seat_keyboard_state,
+    touch_state, WLR_seat_touch_state,
+    display_destroy, WL_listener,
+    selection_source_destroy, WL_listener,
+    primary_selection_source_destroy, WL_listener,
+    drag_source_destroy, WL_listener,
+    events pointer_grab_begin, WL_signal,
+    events pointer_grab_end, WL_signal,
+    events keyboard_grab_begin, WL_signal,
+    events keyboard_grab_end, WL_signal,
+    events touch_grab_begin, WL_signal,
+    events touch_grab_end, WL_signal,
+    events request_set_cursor, WL_signal,
+    events request_set_selection, WL_signal,
+    events set_selection, WL_signal,
+    events request_set_primary_selection, WL_signal,
+    events set_primary_selection, WL_signal,
+    events request_start_drag, WL_signal,
+    events start_drag, WL_signal,
+    events destroy, WL_signal,
+    data, Ptr ()
+}}
+
+-- TODO interface was a ConstPtr
+
+{{ struct
+    wlr/types/wlr_seat.h,
+    wlr_seat_keyboard_grab,
+    interface, Ptr WLR_keyboard_grab_interface,
+    seat, Ptr WLR_seat,
+    data, Ptr ()
+}}
+
+-- TODO enter's CUInt final parameter is a const array
+
+{{ struct
+    wlr/types/wlr_seat.h,
+    wlr_keyboard_grab_interface,
+    enter, FunPtr (Ptr WLR_seat_keyboard_grab -> Ptr WLR_surface -> CUInt -> IO ()),
+    clear_focus, FunPtr (Ptr WLR_seat_keyboard_grab -> IO ()),
+    key, FunPtr (Ptr WLR_seat_keyboard_grab -> CUInt -> CUInt -> CUInt -> IO ()),
+    modifiers, FunPtr (Ptr WLR_seat_keyboard_grab -> Ptr WLR_keyboard_modifiers -> IO ()),
+    cancel, FunPtr (Ptr WLR_seat_keyboard_grab -> IO ())
+}}

--- a/src/WLR/Util/Time.hsc
+++ b/src/WLR/Util/Time.hsc
@@ -1,0 +1,13 @@
+module WLR.Util.Time where
+
+import Foreign.C.Types (CLong, CTime)
+import Foreign.Storable (Storable(..))
+
+#include <time.h>
+
+{{ struct
+    time.h,
+    timespec,
+    tv_sec, CTime,
+    tv_nsec, CLong
+}}

--- a/wlhs-bindings.cabal
+++ b/wlhs-bindings.cabal
@@ -24,23 +24,31 @@ library
         WL.Keyboard
         WL.ServerProtocol
         WL.Utils
+        WL.Global
         WL.Version
+        WL.Client
         WLR.Backend
+        WLR.Types.DataDevice
         WLR.Render.Allocator
+        WLR.Render.Texture
         WLR.Render.DrmFormatSet
         WLR.Render.Renderer
+        WLR.Types.Compositor
         WLR.Types.Buffer
         WLR.Types.InputDevice
         WLR.Types.Pointer
         WLR.Types.Keyboard
         WLR.Types.KeyboardGroup
+        WLR.Types.Seat
+        WLR.Types.PrimarySelection
         WLR.Util.Addon
         WLR.Util.Box
         WLR.Util.Edges
         WLR.Util.Log
         WLR.Version
+        Pixman.Types.Region
 
-    pkgconfig-depends:  wlroots ==0.17.1, wayland-server
+    pkgconfig-depends:  wlroots ==0.17.1, wayland-server, pixman-1
     hs-source-dirs:     src
     default-language:   Haskell2010
     default-extensions: CApiFFI

--- a/wlhs-bindings.cabal
+++ b/wlhs-bindings.cabal
@@ -20,6 +20,7 @@ custom-setup
 
 library
     exposed-modules:
+        WLR.Util.Time
         WL.ServerCore
         WL.Keyboard
         WL.ServerProtocol
@@ -39,13 +40,13 @@ library
         WLR.Types.Pointer
         WLR.Types.Keyboard
         WLR.Types.KeyboardGroup
-        WLR.Types.Seat
         WLR.Types.PrimarySelection
         WLR.Util.Addon
         WLR.Util.Box
         WLR.Util.Edges
         WLR.Util.Log
         WLR.Version
+        WLR.Types.Seat
         Pixman.Types.Region
 
     pkgconfig-depends:  wlroots ==0.17.1, wayland-server, pixman-1


### PR DESCRIPTION
There are still definitions in this file that I haven't written on the Haskell side yet.

It took me a long time because I had to figure out how to handle import cycles, and I had to figure out what to do about things from `time.h` and the like (libraries other than wlroots).

I notice I can find definitions in wlroots's source fairly easily, but transitive dependencies are hard.

I tried bumping our `base` dependency to >= 4.18.0 to use the ConstPtr type for the C FFI, but I couldn't get it to build.
https://hackage.haskell.org/package/base-4.19.0.0/docs/Foreign-C-ConstPtr.html

I'm still not doing validation. I guess we'll find out when we try to get TinyWL working. We could automate it somehow but I only know how to use HUnit, and I'm not sure what testing practices are typical for language bindings.